### PR TITLE
Add PowerShell cloud modules to DSC and Unix bootstrap

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -121,7 +121,14 @@ jobs:
         with:
           script: |
             const needs = JSON.parse(process.env.NEEDS_CONTEXT);
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const runUrl = [
+              context.serverUrl,
+              context.repo.owner,
+              context.repo.repo,
+              'actions',
+              'runs',
+              context.runId,
+            ].join('/');
 
             const jobs = [
               {

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ cd ~/dotfiles
 ./install.sh
 ```
 
+macOS と apt ベースの Linux / WSL では、ブートストラップ中に PowerShell 7 と
+`Az` / `Microsoft.Entra` / `Microsoft.Graph` モジュールもセットアップします。
+
 ### Windows
 
 ```powershell
@@ -86,10 +89,13 @@ winget configure -f "$(chezmoi source-path)\..\reference\windows\configuration.d
 gh auth login
 mise install
 
-# 5. APM で Copilot CLI 設定を適用
+# 5. PowerShell モジュール（Az / Microsoft.Entra / Microsoft.Graph）は
+#    winget configure でセットアップ済み
+
+# 6. APM で Copilot CLI 設定を適用
 apm install
 
-# 6. Visual Studio の設定をインポート（手動）
+# 7. Visual Studio の設定をインポート（手動）
 #    Tools > Import and Export Settings > Import selected environment settings
 #    ファイル: ~/.visualstudio/vscode2026insider.vssettings
 ```

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -20,6 +20,7 @@ winget configure validate -f "$(chezmoi source-path)\reference\windows\configura
 | カテゴリ | 内容 |
 |----------|------|
 | シェル・ターミナル | PowerShell 7, Windows Terminal, Windows Terminal Preview, Oh My Posh |
+| PowerShell モジュール | Az, Microsoft Entra, Microsoft Graph |
 | バージョン管理 | Git, GitHub CLI, GitHub Desktop, ghq, Komac |
 | dotfiles・設定管理 | chezmoi, mise, APM, Desired State Configuration, App Installer |
 | 開発ツール | fzf, lastexecrecord, PowerToys, WinGet Studio, MSIX ツール, Edit, GitHub Copilot for CLI (Prerelease) |
@@ -43,6 +44,9 @@ DSC v3 ネイティブ文書（`dsc config set` コマンド用）とは構造�
 
 また、現在の `configuration.dsc.yaml` は WinGet export ベースラインに合わせているため、
 一部のアプリは `msstore` ソースや依存ランタイムを含めて明示的に列挙しています。
+
+PowerShell 7 の導入後に `pwsh` から `Az` / `Microsoft.Entra` / `Microsoft.Graph`
+モジュールを CurrentUser スコープへ追加する Script リソースも含みます。
 
 ---
 

--- a/home/run_once_after_05-setup-mise-path.ps1
+++ b/home/run_once_after_05-setup-mise-path.ps1
@@ -1,4 +1,4 @@
-# Windows: run_once_after_05-setup-mise-path.ps1
+﻿# Windows: run_once_after_05-setup-mise-path.ps1
 # mise shims を User PATH に永続追加する
 # chezmoi が Windows で初回実行時のみ実行する
 
@@ -8,18 +8,18 @@ $ErrorActionPreference = 'Stop'
 $miseShims = "$env:LOCALAPPDATA\mise\shims"
 
 if (-not (Test-Path $miseShims)) {
-  Write-Host "⚠️  mise shims ディレクトリが見つかりません: $miseShims" -ForegroundColor Yellow
-  Write-Host "   winget configure で mise をインストール後に再実行してください。"
+  Write-Warning "mise shims ディレクトリが見つかりません: $miseShims"
+  Write-Output "   winget configure で mise をインストール後に再実行してください。"
   exit 0
 }
 
 $currentPath = [System.Environment]::GetEnvironmentVariable('PATH', 'User')
 if ($currentPath -notlike "*$miseShims*") {
-  Write-Host "==> mise shims を User PATH に追加します: $miseShims"
+  Write-Output "==> mise shims を User PATH に追加します: $miseShims"
   $newPath = "$miseShims;$currentPath"
   [System.Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')
   $env:PATH = "$miseShims;$env:PATH"
-  Write-Host "==> PATH 更新完了。新しいターミナルで有効になります。"
+  Write-Output "==> PATH 更新完了。新しいターミナルで有効になります。"
 } else {
-  Write-Host "==> mise shims は既に PATH にあります"
+  Write-Output "==> mise shims は既に PATH にあります"
 }

--- a/home/run_once_after_15-install-powershell-modules.sh
+++ b/home/run_once_after_15-install-powershell-modules.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Install common PowerShell modules after PowerShell itself is available.
+
+set -e
+
+if ! command -v pwsh >/dev/null 2>&1; then
+  echo "==> pwsh が見つからないため、PowerShell モジュールのインストールをスキップします" >&2
+  exit 0
+fi
+
+echo "==> PowerShell モジュールをインストールします..."
+
+pwsh -NoLogo -NoProfile -Command '
+$ErrorActionPreference = "Stop"
+
+if (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue) {
+  Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+}
+
+$modules = @(
+  "Az",
+  "Microsoft.Entra",
+  "Microsoft.Graph"
+)
+
+foreach ($name in $modules) {
+  if (Get-Module -ListAvailable -Name $name) {
+    Write-Host "==> $name は既にインストール済みです"
+    continue
+  }
+
+  Write-Host "==> $name をインストールします..."
+  Install-Module -Name $name -Repository PSGallery -Scope CurrentUser -Force -AllowClobber
+}
+'

--- a/home/run_once_after_15-install-powershell-modules.sh
+++ b/home/run_once_after_15-install-powershell-modules.sh
@@ -13,8 +13,11 @@ echo "==> PowerShell モジュールをインストールします..."
 pwsh -NoLogo -NoProfile -Command '
 $ErrorActionPreference = "Stop"
 
-if (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue) {
-  Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+$psGallery = Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue
+$previousInstallationPolicy = $null
+
+if ($psGallery) {
+  $previousInstallationPolicy = $psGallery.InstallationPolicy
 }
 
 $modules = @(
@@ -23,13 +26,24 @@ $modules = @(
   "Microsoft.Graph"
 )
 
-foreach ($name in $modules) {
-  if (Get-Module -ListAvailable -Name $name) {
-    Write-Host "==> $name は既にインストール済みです"
-    continue
+try {
+  if ($psGallery -and $previousInstallationPolicy -ne "Trusted") {
+    Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
   }
 
-  Write-Host "==> $name をインストールします..."
-  Install-Module -Name $name -Repository PSGallery -Scope CurrentUser -Force -AllowClobber
+  foreach ($name in $modules) {
+    if (Get-Module -ListAvailable -Name $name) {
+      Write-Host "==> $name は既にインストール済みです"
+      continue
+    }
+
+    Write-Host "==> $name をインストールします..."
+    Install-Module -Name $name -Repository PSGallery -Scope CurrentUser -Force -AllowClobber
+  }
+}
+finally {
+  if ($psGallery -and $previousInstallationPolicy -and $previousInstallationPolicy -ne "Trusted") {
+    Set-PSRepository -Name PSGallery -InstallationPolicy $previousInstallationPolicy
+  }
 }
 '

--- a/home/run_once_after_40-install-volta-packages.ps1
+++ b/home/run_once_after_40-install-volta-packages.ps1
@@ -1,8 +1,8 @@
-# Install Volta-managed global npm packages listed in apm.yml
+﻿# Install Volta-managed global npm packages listed in apm.yml
 $ErrorActionPreference = 'Stop'
 
 if (-not (Get-Command volta -ErrorAction SilentlyContinue)) {
-    Write-Host "volta not found, skipping global npm package install"
+    Write-Output "volta not found, skipping global npm package install"
     exit 0
 }
 

--- a/home/run_once_after_50-import-vs-settings.ps1
+++ b/home/run_once_after_50-import-vs-settings.ps1
@@ -1,4 +1,4 @@
-# Visual Studio settings import reminder (Windows only)
+﻿# Visual Studio settings import reminder (Windows only)
 # The .vssettings file has been deployed to ~/.visualstudio/
 # Import manually via: Tools > Import and Export Settings > Import selected environment settings
 
@@ -6,14 +6,14 @@ if (-not $IsWindows) { exit 0 }
 
 $settingsFile = Join-Path $HOME ".visualstudio\vscode2026insider.vssettings"
 if (Test-Path $settingsFile) {
-    Write-Host ""
-    Write-Host "========================================" -ForegroundColor Cyan
-    Write-Host " Visual Studio Settings" -ForegroundColor Cyan
-    Write-Host "========================================" -ForegroundColor Cyan
-    Write-Host "To import your saved settings, open Visual Studio and go to:"
-    Write-Host "  Tools > Import and Export Settings > Import selected environment settings"
-    Write-Host ""
-    Write-Host "Settings file: $settingsFile" -ForegroundColor Yellow
-    Write-Host "========================================" -ForegroundColor Cyan
-    Write-Host ""
+    Write-Output ""
+    Write-Output "========================================"
+    Write-Output " Visual Studio Settings"
+    Write-Output "========================================"
+    Write-Output "To import your saved settings, open Visual Studio and go to:"
+    Write-Output "  Tools > Import and Export Settings > Import selected environment settings"
+    Write-Output ""
+    Write-Output "Settings file: $settingsFile"
+    Write-Output "========================================"
+    Write-Output ""
 }

--- a/home/run_once_before_10-install-packages.ps1
+++ b/home/run_once_before_10-install-packages.ps1
@@ -1,4 +1,4 @@
-# Windows: run_once_before_10-install-packages.ps1
+﻿# Windows: run_once_before_10-install-packages.ps1
 # winget でブートストラップに必要な最小パッケージをインストール
 # chezmoi が Windows で初回実行時のみ実行する
 
@@ -15,9 +15,9 @@ foreach ($id in $packages) {
   $installed = winget list --id $id --accept-source-agreements 2>&1 |
                Where-Object { $_ -match $id }
   if (-not $installed) {
-    Write-Host "==> $id をインストールします..."
+    Write-Output "==> $id をインストールします..."
     winget install --id $id --accept-package-agreements --accept-source-agreements
   } else {
-    Write-Host "==> $id は既にインストール済みです"
+    Write-Output "==> $id は既にインストール済みです"
   }
 }

--- a/home/run_once_before_10-install-packages.sh
+++ b/home/run_once_before_10-install-packages.sh
@@ -5,6 +5,41 @@
 
 set -e
 
+install_powershell_apt() {
+  if command -v pwsh >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if [ ! -r /etc/os-release ]; then
+    echo "==> /etc/os-release が見つからないため、PowerShell の自動インストールをスキップします" >&2
+    return 0
+  fi
+
+  # shellcheck disable=SC1091
+  . /etc/os-release
+
+  case "$ID" in
+    ubuntu|debian)
+      ;;
+    *)
+      echo "==> $ID では PowerShell の自動インストールをスキップします" >&2
+      return 0
+      ;;
+  esac
+
+  sudo apt-get install -y --no-install-recommends apt-transport-https gpg
+
+  if ! dpkg -s packages-microsoft-prod >/dev/null 2>&1; then
+    tmp_deb="$(mktemp)"
+    curl -fsSL "https://packages.microsoft.com/config/$ID/$VERSION_ID/packages-microsoft-prod.deb" -o "$tmp_deb"
+    sudo dpkg -i "$tmp_deb"
+    rm -f "$tmp_deb"
+    sudo apt-get update -qq
+  fi
+
+  sudo apt-get install -y --no-install-recommends powershell
+}
+
 OS="$(uname -s)"
 
 if [ "$OS" = "Darwin" ]; then
@@ -14,6 +49,9 @@ if [ "$OS" = "Darwin" ]; then
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   fi
   brew install git curl fzf gh gitleaks
+  if ! command -v pwsh >/dev/null 2>&1; then
+    brew install --cask powershell
+  fi
 
 elif [ "$OS" = "Linux" ]; then
   # Linux / WSL — apt
@@ -22,5 +60,6 @@ elif [ "$OS" = "Linux" ]; then
     sudo apt-get install -y --no-install-recommends \
       git curl unzip ca-certificates build-essential \
       fzf
+    install_powershell_apt
   fi
 fi

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-# Windows ブートストラップスクリプト
+﻿# Windows ブートストラップスクリプト
 # 使い方: ./install.ps1（PowerShell 7 以上を推奨）
 #
 # 手順:
@@ -10,27 +10,27 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Write-Host "==> dotfiles セットアップを開始します (Windows)" -ForegroundColor Cyan
+Write-Output "==> dotfiles セットアップを開始します (Windows)"
 
 # chezmoi がなければインストール
 if (-not (Get-Command chezmoi -ErrorAction SilentlyContinue)) {
-  Write-Host "==> chezmoi をインストールします..."
+  Write-Output "==> chezmoi をインストールします..."
   winget install --id twpayne.chezmoi --accept-package-agreements --accept-source-agreements
 }
 
 # chezmoi init & apply
-Write-Host "==> chezmoi init & apply を実行します..."
+Write-Output "==> chezmoi init & apply を実行します..."
 chezmoi init --apply kkamegawa
 
 # WinGet Configuration で Windows 環境を構成
 $dscFile = "$(chezmoi source-path)\reference\windows\configuration.dsc.yaml"
 if (Test-Path $dscFile) {
-  Write-Host "==> WinGet Configuration を適用します..."
+  Write-Output "==> WinGet Configuration を適用します..."
   winget configure -f $dscFile --accept-configuration-agreements
 }
 
-Write-Host ""
-Write-Host "==> セットアップ完了。続けて以下を実行してください:" -ForegroundColor Green
-Write-Host "    gh auth login"
-Write-Host "    mise install"
-Write-Host "    apm install"
+Write-Output ""
+Write-Output "==> セットアップ完了。続けて以下を実行してください:"
+Write-Output "    gh auth login"
+Write-Output "    mise install"
+Write-Output "    apm install"

--- a/reference/windows/configuration.dsc.yaml
+++ b/reference/windows/configuration.dsc.yaml
@@ -45,6 +45,63 @@ properties:
         id: Microsoft.PowerShell
         source: winget
 
+    - resource: PSDscResources/Script
+      id: powershell-modules
+      directives:
+        description: PowerShell modules (Az, Microsoft Entra, Microsoft Graph)
+      settings:
+        GetScript: |
+          $pwsh = (Get-Command pwsh.exe -ErrorAction SilentlyContinue).Source
+          if (-not $pwsh) {
+            return @{ Result = 'pwsh-not-installed' }
+          }
+
+          $installed = & $pwsh -NoLogo -NoProfile -Command '
+            $modules = @("Az", "Microsoft.Entra", "Microsoft.Graph")
+            ($modules | Where-Object { Get-Module -ListAvailable -Name $_ }).Count
+          '
+          return @{ Result = "$installed/3" }
+        TestScript: |
+          $pwsh = (Get-Command pwsh.exe -ErrorAction SilentlyContinue).Source
+          if (-not $pwsh) {
+            return $false
+          }
+
+          & $pwsh -NoLogo -NoProfile -Command '
+            $modules = @("Az", "Microsoft.Entra", "Microsoft.Graph")
+            foreach ($name in $modules) {
+              if (-not (Get-Module -ListAvailable -Name $name)) {
+                exit 1
+              }
+            }
+          '
+          return $LASTEXITCODE -eq 0
+        SetScript: |
+          $pwsh = (Get-Command pwsh.exe -ErrorAction Stop).Source
+          $moduleInstallScript = @'
+          $ErrorActionPreference = "Stop"
+
+          if (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue) {
+            Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          }
+
+          $modules = @(
+            "Az",
+            "Microsoft.Entra",
+            "Microsoft.Graph"
+          )
+
+          foreach ($name in $modules) {
+            if (Get-Module -ListAvailable -Name $name) {
+              continue
+            }
+
+            Install-Module -Name $name -Repository PSGallery -Scope CurrentUser -Force -AllowClobber
+          }
+          '@
+
+          & $pwsh -NoLogo -NoProfile -Command $moduleInstallScript
+
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: windows-terminal
       directives:

--- a/reference/windows/configuration.dsc.yaml
+++ b/reference/windows/configuration.dsc.yaml
@@ -51,7 +51,22 @@ properties:
         description: PowerShell modules (Az, Microsoft Entra, Microsoft Graph)
       settings:
         GetScript: |
-          $pwsh = (Get-Command pwsh.exe -ErrorAction SilentlyContinue).Source
+          function Resolve-PwshPath {
+            $candidates = @(
+              (Join-Path $env:ProgramFiles 'PowerShell\7\pwsh.exe'),
+              (Join-Path ${env:ProgramFiles(x86)} 'PowerShell\7\pwsh.exe')
+            )
+
+            foreach ($candidate in $candidates) {
+              if ($candidate -and (Test-Path $candidate)) {
+                return $candidate
+              }
+            }
+
+            return (Get-Command pwsh.exe -ErrorAction SilentlyContinue).Source
+          }
+
+          $pwsh = Resolve-PwshPath
           if (-not $pwsh) {
             return @{ Result = 'pwsh-not-installed' }
           }
@@ -62,7 +77,22 @@ properties:
           '
           return @{ Result = "$installed/3" }
         TestScript: |
-          $pwsh = (Get-Command pwsh.exe -ErrorAction SilentlyContinue).Source
+          function Resolve-PwshPath {
+            $candidates = @(
+              (Join-Path $env:ProgramFiles 'PowerShell\7\pwsh.exe'),
+              (Join-Path ${env:ProgramFiles(x86)} 'PowerShell\7\pwsh.exe')
+            )
+
+            foreach ($candidate in $candidates) {
+              if ($candidate -and (Test-Path $candidate)) {
+                return $candidate
+              }
+            }
+
+            return (Get-Command pwsh.exe -ErrorAction SilentlyContinue).Source
+          }
+
+          $pwsh = Resolve-PwshPath
           if (-not $pwsh) {
             return $false
           }
@@ -77,12 +107,34 @@ properties:
           '
           return $LASTEXITCODE -eq 0
         SetScript: |
-          $pwsh = (Get-Command pwsh.exe -ErrorAction Stop).Source
+          function Resolve-PwshPath {
+            $candidates = @(
+              (Join-Path $env:ProgramFiles 'PowerShell\7\pwsh.exe'),
+              (Join-Path ${env:ProgramFiles(x86)} 'PowerShell\7\pwsh.exe')
+            )
+
+            foreach ($candidate in $candidates) {
+              if ($candidate -and (Test-Path $candidate)) {
+                return $candidate
+              }
+            }
+
+            return (Get-Command pwsh.exe -ErrorAction SilentlyContinue).Source
+          }
+
+          $pwsh = Resolve-PwshPath
+          if (-not $pwsh) {
+            throw 'pwsh.exe was not found after installing PowerShell 7.'
+          }
+
           $moduleInstallScript = @'
           $ErrorActionPreference = "Stop"
 
-          if (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue) {
-            Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          $psGallery = Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue
+          $previousInstallationPolicy = $null
+
+          if ($psGallery) {
+            $previousInstallationPolicy = $psGallery.InstallationPolicy
           }
 
           $modules = @(
@@ -91,12 +143,23 @@ properties:
             "Microsoft.Graph"
           )
 
-          foreach ($name in $modules) {
-            if (Get-Module -ListAvailable -Name $name) {
-              continue
+          try {
+            if ($psGallery -and $previousInstallationPolicy -ne "Trusted") {
+              Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
             }
 
-            Install-Module -Name $name -Repository PSGallery -Scope CurrentUser -Force -AllowClobber
+            foreach ($name in $modules) {
+              if (Get-Module -ListAvailable -Name $name) {
+                continue
+              }
+
+              Install-Module -Name $name -Repository PSGallery -Scope CurrentUser -Force -AllowClobber
+            }
+          }
+          finally {
+            if ($psGallery -and $previousInstallationPolicy -and $previousInstallationPolicy -ne "Trusted") {
+              Set-PSRepository -Name PSGallery -InstallationPolicy $previousInstallationPolicy
+            }
           }
           '@
 
@@ -557,10 +620,16 @@ properties:
         securityContext: elevated
       settings:
         GetScript: |
-          $val = Get-ItemPropertyValue -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock' -Name AllowDevelopmentWithoutDevLicense -ErrorAction SilentlyContinue
+          $val = Get-ItemPropertyValue `
+            -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock' `
+            -Name AllowDevelopmentWithoutDevLicense `
+            -ErrorAction SilentlyContinue
           return @{ Result = "$val" }
         TestScript: |
-          $val = Get-ItemPropertyValue -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock' -Name AllowDevelopmentWithoutDevLicense -ErrorAction SilentlyContinue
+          $val = Get-ItemPropertyValue `
+            -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock' `
+            -Name AllowDevelopmentWithoutDevLicense `
+            -ErrorAction SilentlyContinue
           return $val -eq 1
         SetScript: |
           $regPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock'
@@ -598,7 +667,9 @@ properties:
           New-Item -ItemType Directory -Force -Path $tmp | Out-Null
           $tag = (Invoke-RestMethod "https://api.github.com/repos/githubnext/monaspace/releases/latest").tag_name
           $zip = Join-Path $tmp "monaspace.zip"
-          Invoke-WebRequest -Uri "https://github.com/githubnext/monaspace/releases/download/$tag/monaspace-$tag.zip" -OutFile $zip
+          Invoke-WebRequest `
+            -Uri "https://github.com/githubnext/monaspace/releases/download/$tag/monaspace-$tag.zip" `
+            -OutFile $zip
           Expand-Archive -Path $zip -DestinationPath $tmp -Force
           $fontDir = "$env:LOCALAPPDATA\Microsoft\Windows\Fonts"
           New-Item -ItemType Directory -Force -Path $fontDir | Out-Null
@@ -624,7 +695,9 @@ properties:
           $tmp = Join-Path $env:TEMP "plemonjp"
           New-Item -ItemType Directory -Force -Path $tmp | Out-Null
           $release = Invoke-RestMethod "https://api.github.com/repos/yuru7/PlemolJP/releases/latest"
-          $asset = $release.assets | Where-Object { $_.name -match "PlemolJP_Console_NF_.*\.zip" } | Select-Object -First 1
+          $asset = $release.assets |
+            Where-Object { $_.name -match "PlemolJP_Console_NF_.*\.zip" } |
+            Select-Object -First 1
           $zip = Join-Path $tmp "plemonjp.zip"
           Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zip
           Expand-Archive -Path $zip -DestinationPath $tmp -Force

--- a/scripts/tool-spec-watch.ps1
+++ b/scripts/tool-spec-watch.ps1
@@ -79,7 +79,7 @@ function Get-MajorVersion {
     return [int]$match.Groups[1].Value
 }
 
-function Get-MatchedKeywords {
+function Get-MatchedKeyword {
     param(
         [AllowNull()]
         [string]$Text,
@@ -88,9 +88,9 @@ function Get-MatchedKeywords {
         [string[]]$Keywords
     )
 
-    $matches = [System.Collections.Generic.List[string]]::new()
+    $keywordMatches = [System.Collections.Generic.List[string]]::new()
     if ([string]::IsNullOrWhiteSpace($Text)) {
-        return $matches.ToArray()
+        return $keywordMatches.ToArray()
     }
 
     $normalized = $Text.ToLowerInvariant()
@@ -100,11 +100,11 @@ function Get-MatchedKeywords {
         }
 
         if ($normalized.Contains($keyword.ToLowerInvariant())) {
-            $matches.Add($keyword)
+            $keywordMatches.Add($keyword)
         }
     }
 
-    return ($matches | Select-Object -Unique)
+    return ($keywordMatches | Select-Object -Unique)
 }
 
 function Get-ObjectValue {
@@ -233,7 +233,7 @@ function Get-GitHubReleaseInfo {
     }
 }
 
-function New-Finding {
+function ConvertTo-Finding {
     param(
         [Parameter(Mandatory = $true)]
         [pscustomobject]$Tool,
@@ -332,7 +332,7 @@ foreach ($tool in @($config.tools)) {
             }
 
             $keywords = @($defaultKeywords + @(Get-OptionalPropertyValue -InputObject $tool -PropertyName 'keywords' -DefaultValue @())) | Select-Object -Unique
-            $matchedKeywords = @(Get-MatchedKeywords -Text ([string]$release.Body) -Keywords $keywords)
+            $matchedKeywords = @(Get-MatchedKeyword -Text ([string]$release.Body) -Keywords $keywords)
             if ($matchedKeywords.Count -gt 0) {
                 $reasons.Add("リリースノートに注目キーワードが含まれています。($($matchedKeywords -join ', '))")
             }
@@ -342,7 +342,7 @@ foreach ($tool in @($config.tools)) {
             }
 
             if ($reasons.Count -gt 0) {
-                $findings.Add((New-Finding `
+                $findings.Add((ConvertTo-Finding `
                     -Tool $tool `
                     -Signal 'upstream release change' `
                     -Baseline $knownVersion `
@@ -372,7 +372,7 @@ foreach ($tool in @($config.tools)) {
             }
 
             if ($reasons.Count -gt 0) {
-                $findings.Add((New-Finding `
+                $findings.Add((ConvertTo-Finding `
                     -Tool $tool `
                     -Signal 'documentation update' `
                     -Baseline $knownDocumentDate `
@@ -401,7 +401,7 @@ foreach ($tool in @($config.tools)) {
             }
 
             if ($reasons.Count -gt 0) {
-                $findings.Add((New-Finding `
+                $findings.Add((ConvertTo-Finding `
                     -Tool $tool `
                     -Signal 'schema change' `
                     -Baseline ($baselineValues -join '; ') `

--- a/scripts/tool-spec-watch.ps1
+++ b/scripts/tool-spec-watch.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding()]
+﻿[CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
     [string]$ConfigPath,
@@ -428,7 +428,7 @@ Write-StepSummaryLine -Line ''
 
 if ($findings.Count -eq 0) {
     Write-StepSummaryLine -Line 'No actionable upstream changes detected.'
-    Write-Host 'No actionable upstream changes detected.'
+    Write-Output 'No actionable upstream changes detected.'
     exit 0
 }
 
@@ -439,4 +439,4 @@ foreach ($finding in $findings) {
     Write-StepSummaryLine -Line "| $($finding.displayName) | $($finding.signal) | $($finding.current) | $($finding.baseline) |"
 }
 
-Write-Host "Detected $($findings.Count) actionable upstream change(s)."
+Write-Output "Detected $($findings.Count) actionable upstream change(s)."


### PR DESCRIPTION
## Summary
This adds the Azure, Microsoft Entra, and Microsoft Graph PowerShell modules to the bootstrap flow so new environments get the same cloud tooling on Windows, macOS, and Linux/WSL.

On Windows, the WinGet DSC configuration now invokes `pwsh` after PowerShell 7 is installed and provisions `Az`, `Microsoft.Entra`, and `Microsoft.Graph` from PSGallery. On macOS and apt-based Linux/WSL, the bootstrap installs PowerShell 7 if needed and then runs a dedicated chezmoi `run_once` script to install the same modules.

## Notes
- The PowerShell modules are installed with `CurrentUser` scope to avoid requiring a separate elevated PowerShell module install step.
- Automatic PowerShell installation on Linux follows the existing apt-based bootstrap pattern and skips unsupported distros with a visible message.
- README and Windows setup docs were updated to reflect the new module provisioning path.