### PR TITLE
Add macOS Homebrew package bootstrap

### DIFF
--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -41,3 +41,7 @@ SAVEHIST=50000
 setopt SHARE_HISTORY
 setopt HIST_IGNORE_DUPS
 setopt HIST_IGNORE_SPACE
+
+# User additions
+# Put machine-local zsh customizations in ~/.zshrc.local.
+[ -f "$HOME/.zshrc.local" ] && source "$HOME/.zshrc.local"

--- a/home/run_once_before_10-install-homebrew-packages.sh
+++ b/home/run_once_before_10-install-homebrew-packages.sh
@@ -67,7 +67,6 @@ copilot-cli@prerelease
 daisydisk
 devtoys
 discord
-docker
 docker-desktop
 dotnet-sdk
 firefox

--- a/home/run_once_before_10-install-homebrew-packages.sh
+++ b/home/run_once_before_10-install-homebrew-packages.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+# Install macOS packages managed directly by Homebrew.
+# Node.js and Python runtimes are intentionally excluded; use Volta and uv instead.
+
+set -e
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  exit 0
+fi
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "==> Installing Homebrew..."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
+
+if [ -x /opt/homebrew/bin/brew ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -x /usr/local/bin/brew ]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
+
+install_formulae() {
+  while IFS= read -r formula; do
+    [ -n "$formula" ] || continue
+    brew install "$formula"
+  done <<'EOF'
+ansible
+ansible-lint
+azure-cli
+azure/azd/azd
+azure/bicep/bicep
+azure/functions/azure-functions-core-tools@4
+cmake
+curl
+docker-completion
+docker-squash
+gh
+git
+git-lfs
+hashicorp/tap/packer
+jq
+komac
+micro
+microsoft/foundrylocal/foundrylocal
+oh-my-posh
+powershell
+starship
+termscp
+uv
+volta
+wget
+EOF
+}
+
+install_casks() {
+  while IFS= read -r cask; do
+    [ -n "$cask" ] || continue
+    brew install --cask "$cask"
+  done <<'EOF'
+1password
+1password-cli
+adobe-creative-cloud
+bing-wallpaper
+blender
+cleanshot
+copilot-cli@prerelease
+daisydisk
+devtoys
+discord
+docker
+docker-desktop
+dotnet-sdk
+firefox
+font-biz-udgothic
+font-biz-udmincho
+font-biz-udpgothic
+font-biz-udpmincho
+font-cica
+font-jetbrains-mono-nerd-font
+font-monaspace
+font-noto-sans-cjk-jp
+font-noto-sans-mono-cjk-jp
+font-plemol-jp
+font-plemol-jp-nf
+ghostty
+git-credential-manager
+github
+github-copilot-for-xcode
+google-chrome
+intune-company-portal
+iterm2
+jetbrains-toolbox
+karabiner-elements
+maccy
+microsoft-auto-update
+microsoft-azure-storage-explorer
+microsoft-edge
+microsoft-edge@beta
+microsoft-edge@dev
+microsoft-openjdk
+microsoft-openjdk@17
+spotify
+visual-studio-code
+visual-studio-code@insiders
+zoom
+EOF
+}
+
+install_formulae
+install_casks

--- a/home/run_once_before_10-install-packages.sh
+++ b/home/run_once_before_10-install-packages.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # run_once_before_10-install-packages.sh
-# パッケージマネージャー（Homebrew / apt）で基本パッケージをインストール
-# chezmoi が初回実行時のみ実行する
+# Install base packages with apt on Linux / WSL.
+# chezmoi runs this script only once.
 
 set -e
 
@@ -42,19 +42,8 @@ install_powershell_apt() {
 
 OS="$(uname -s)"
 
-if [ "$OS" = "Darwin" ]; then
-  # macOS — Homebrew
-  if ! command -v brew >/dev/null 2>&1; then
-    echo "==> Homebrew をインストールします..."
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-  fi
-  brew install git curl fzf gh gitleaks
-  if ! command -v pwsh >/dev/null 2>&1; then
-    brew install --cask powershell
-  fi
-
-elif [ "$OS" = "Linux" ]; then
-  # Linux / WSL — apt
+if [ "$OS" = "Linux" ]; then
+  # Linux / WSL - apt
   if command -v apt-get >/dev/null 2>&1; then
     sudo apt-get update -qq
     sudo apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

This separates macOS Homebrew package setup from the shared Linux/WSL package bootstrap so each platform has a clearer, safer install path.

- Add a macOS-only Homebrew run-once script with direct formulae and casks from the current machine package set.
- Keep Node.js and Python runtimes out of Homebrew direct installs so they stay managed by Volta and uv/mise.
- Simplify the existing package script to Linux/WSL apt setup only.
- Add a `~/.zshrc.local` hook for machine-local zsh customizations.

## Notes

No existing TOML/JSON dotfile was clearly macOS-only, so no `.chezmoiignore` OS gate was added for those files.

Closes #4