### PR TITLE
Fix OS-specific package installer separation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,6 +68,19 @@ jobs:
         run: |
           chezmoi init --source "$GITHUB_WORKSPACE" --dry-run --verbose
 
+  chezmoi-dry-run-macos:
+    name: chezmoi dry-run (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install chezmoi
+        run: |
+          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: chezmoi dry-run (macOS)
+        run: |
+          chezmoi init --source "$GITHUB_WORKSPACE" --dry-run --verbose
+
   chezmoi-dry-run-windows:
     name: chezmoi dry-run (Windows)
     runs-on: windows-latest
@@ -112,6 +125,7 @@ jobs:
       - shellcheck
       - yamllint
       - chezmoi-dry-run-linux
+      - chezmoi-dry-run-macos
       - chezmoi-dry-run-windows
       - winget-config-validate
     steps:
@@ -149,6 +163,12 @@ jobs:
                 title: '[ci-failure] lint / chezmoi dry-run (Linux)',
                 files: ['.github/workflows/lint.yml', '.chezmoi.toml.tmpl', 'dot_*', 'private_dot_*'],
                 summary: 'Ubuntu の chezmoi dry-run job が失敗しました。',
+              },
+              {
+                id: 'chezmoi-dry-run-macos',
+                title: '[ci-failure] lint / chezmoi dry-run (macOS)',
+                files: ['.github/workflows/lint.yml', '.chezmoi.toml.tmpl', 'run_once_*', 'dot_*', 'private_dot_*'],
+                summary: 'macOS の chezmoi dry-run job が失敗しました。',
               },
               {
                 id: 'chezmoi-dry-run-windows',

--- a/docs/homebrew_en.md
+++ b/docs/homebrew_en.md
@@ -8,6 +8,10 @@ Some cask applications update themselves outside Homebrew. When those apps are a
 
 The bootstrap treats casks as install-only during dotfiles setup. It skips a cask when Homebrew already lists that cask as installed, so `brew install --cask` does not trigger an implicit upgrade during bootstrap.
 
-For casks marked `auto_updates` in Homebrew metadata, the bootstrap also skips the cask when the application bundle declared by the cask already exists in `/Applications` or `~/Applications`, even if Homebrew does not list that cask as installed.
+For casks marked `auto_updates` in Homebrew metadata, the bootstrap treats the first successful install as the only Homebrew-managed install. Later runs skip the cask when Homebrew metadata records it as installed. If the cask was installed outside Homebrew, the bootstrap also skips it when an application bundle declared by the cask exists in `/Applications`, `~/Applications`, or an absolute `.app` path listed by the cask metadata.
 
 This keeps first-time setup behavior intact for new machines while avoiding repeated Homebrew work for apps that manage their own updates. Casks that are missing continue to use the normal `brew install --cask` path.
+
+## Sudo handling for casks
+
+Formula installation does not keep sudo alive. Immediately before cask installation starts, the bootstrap runs `sudo -v` once and keeps that sudo timestamp active only while the cask batch is running. This avoids repeated password prompts from cask installers without leaving a long-lived sudo keepalive process after the bootstrap finishes.

--- a/docs/homebrew_ja.md
+++ b/docs/homebrew_ja.md
@@ -8,6 +8,10 @@ macOS のブートストラップでは、先に Homebrew formula をインス�
 
 dotfiles のセットアップでは、cask をインストール専用として扱います。Homebrew がその cask をインストール済みとして認識している場合はスキップし、ブートストラップ中の `brew install --cask` が暗黙的なアップグレードを始めないようにします。
 
-Homebrew メタデータで `auto_updates` として扱われる cask は、Homebrew がその cask をインストール済みとして認識していない場合でも、cask が宣言しているアプリケーション bundle が `/Applications` または `~/Applications` に存在すればスキップします。
+Homebrew メタデータで `auto_updates` として扱われる cask は、初回の正常なインストールだけを Homebrew 管理のインストールとして扱います。以降の実行では、Homebrew メタデータがインストール済みと記録していればスキップします。Homebrew 以外の方法でインストール済みの場合も、cask が宣言しているアプリケーション bundle が `/Applications`、`~/Applications`、または cask メタデータ内の絶対 `.app` パスに存在すればスキップします。
 
 これにより、新しいマシンでの初回セットアップは維持しつつ、自分で更新機能を持つアプリに対する Homebrew の再処理を避けます。未インストールの cask は、従来どおり `brew install --cask` を実行します。
+
+## cask の sudo 処理
+
+Formula のインストール中は sudo を維持しません。cask のインストールを開始する直前に `sudo -v` を一度だけ実行し、cask の一括処理が続いている間だけ sudo のタイムスタンプを維持します。これにより、cask インストーラーによるパスワードの再入力を避けつつ、ブートストラップ完了後に sudo 維持プロセスを残しません。

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -1,9 +1,22 @@
-# OS 別除外
+# OS-specific exclusions.
 {{ if ne .chezmoi.os "windows" }}
 PowerShell_profile.ps1
+run_once_before_10-install-packages.ps1
+run_once_after_05-setup-mise-path.ps1
+run_once_after_40-install-volta-packages.ps1
+run_once_after_50-import-vs-settings.ps1
+{{ end }}
+
+{{ if eq .chezmoi.os "windows" }}
+run_once_*.sh
+{{ end }}
+
+{{ if ne .chezmoi.os "linux" }}
+run_once_before_10-install-packages.sh
 {{ end }}
 
 {{ if ne .chezmoi.os "darwin" }}
+run_once_before_10-install-homebrew-packages.sh
 {{ end }}
 
 {{ if .isDevContainer }}

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -1,22 +1,29 @@
 # OS-specific exclusions.
 {{ if ne .chezmoi.os "windows" }}
-PowerShell_profile.ps1
-run_once_before_10-install-packages.ps1
-run_once_after_05-setup-mise-path.ps1
-run_once_after_40-install-volta-packages.ps1
-run_once_after_50-import-vs-settings.ps1
+05-setup-mise-path.ps1
+10-install-packages.ps1
+40-install-volta-packages.ps1
+50-import-vs-settings.ps1
 {{ end }}
 
 {{ if eq .chezmoi.os "windows" }}
-run_once_*.sh
+10-install-homebrew-packages.sh
+10-install-packages.sh
+10-setup-git-hooks.sh
+15-install-powershell-modules.sh
+20-install-mise.sh
+20-mise-install.sh
+30-install-uv.sh
+30-setup-1password.sh
+40-install-volta-packages.sh
 {{ end }}
 
 {{ if ne .chezmoi.os "linux" }}
-run_once_before_10-install-packages.sh
+10-install-packages.sh
 {{ end }}
 
 {{ if ne .chezmoi.os "darwin" }}
-run_once_before_10-install-homebrew-packages.sh
+10-install-homebrew-packages.sh
 {{ end }}
 
 {{ if .isDevContainer }}

--- a/home/run_once_after_05-setup-mise-path.ps1
+++ b/home/run_once_after_05-setup-mise-path.ps1
@@ -1,25 +1,31 @@
-﻿# Windows: run_once_after_05-setup-mise-path.ps1
-# mise shims を User PATH に永続追加する
-# chezmoi が Windows で初回実行時のみ実行する
+# Windows: run_once_after_05-setup-mise-path.ps1
+# Add mise shims to the persistent user PATH.
+# chezmoi should only run this script on Windows.
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+$isWindowsHost = [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+if (-not $isWindowsHost) {
+  Write-Warning 'Skipping Windows mise PATH setup because this host is not Windows.'
+  exit 0
+}
+
 $miseShims = "$env:LOCALAPPDATA\mise\shims"
 
 if (-not (Test-Path $miseShims)) {
-  Write-Warning "mise shims ディレクトリが見つかりません: $miseShims"
-  Write-Output "   winget configure で mise をインストール後に再実行してください。"
+  Write-Warning "mise shims directory was not found: $miseShims"
+  Write-Output '   Install mise with winget configure, then run this script again.'
   exit 0
 }
 
 $currentPath = [System.Environment]::GetEnvironmentVariable('PATH', 'User')
 if ($currentPath -notlike "*$miseShims*") {
-  Write-Output "==> mise shims を User PATH に追加します: $miseShims"
+  Write-Output "==> Adding mise shims to the user PATH: $miseShims"
   $newPath = "$miseShims;$currentPath"
   [System.Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')
   $env:PATH = "$miseShims;$env:PATH"
-  Write-Output "==> PATH 更新完了。新しいターミナルで有効になります。"
+  Write-Output '==> PATH update complete. Open a new terminal to use it.'
 } else {
-  Write-Output "==> mise shims は既に PATH にあります"
+  Write-Output '==> mise shims are already in PATH'
 }

--- a/home/run_once_after_40-install-volta-packages.ps1
+++ b/home/run_once_after_40-install-volta-packages.ps1
@@ -1,5 +1,11 @@
-﻿# Install Volta-managed global npm packages listed in apm.yml
+﻿# Install Volta-managed global npm packages listed in apm.yml.
 $ErrorActionPreference = 'Stop'
+
+$isWindowsHost = [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+if (-not $isWindowsHost) {
+    Write-Warning 'Skipping Windows Volta package installation because this host is not Windows.'
+    exit 0
+}
 
 if (-not (Get-Command volta -ErrorAction SilentlyContinue)) {
     Write-Output "volta not found, skipping global npm package install"

--- a/home/run_once_after_50-import-vs-settings.ps1
+++ b/home/run_once_after_50-import-vs-settings.ps1
@@ -2,7 +2,11 @@
 # The .vssettings file has been deployed to ~/.visualstudio/
 # Import manually via: Tools > Import and Export Settings > Import selected environment settings
 
-if (-not $IsWindows) { exit 0 }
+$isWindowsHost = [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+if (-not $isWindowsHost) {
+    Write-Warning 'Skipping Visual Studio settings reminder because this host is not Windows.'
+    exit 0
+}
 
 $settingsFile = Join-Path $HOME ".visualstudio\vscode2026insider.vssettings"
 if (Test-Path $settingsFile) {

--- a/home/run_once_before_10-install-homebrew-packages.sh
+++ b/home/run_once_before_10-install-homebrew-packages.sh
@@ -19,6 +19,10 @@ stop_sudo_keepalive() {
 }
 
 start_sudo_keepalive() {
+  if [ -n "$SUDO_KEEPALIVE_PID" ]; then
+    return 0
+  fi
+
   if [ "$(id -u)" -eq 0 ]; then
     return 0
   fi
@@ -147,35 +151,36 @@ cask_app_is_installed() {
 
   [ -n "$apps" ] || return 1
 
-  old_ifs=$IFS
-  IFS='
-'
-  found=1
-  for app in $apps; do
+  while IFS= read -r app; do
     case "$app" in
       /*|\~/*)
         if path_exists "$app"; then
-          found=0
+          return 0
         fi
         ;;
       *)
         for app_dir in /Applications "$HOME/Applications"; do
           if [ -e "$app_dir/$app" ]; then
-            found=0
-            break
+            return 0
           fi
         done
         ;;
     esac
-    [ "$found" -ne 0 ] || break
-  done
-  IFS=$old_ifs
+  done <<EOF
+$apps
+EOF
 
-  return "$found"
+  return 1
 }
 
 install_cask() {
   cask=$1
+
+  if brew list --cask "$cask" >/dev/null 2>&1; then
+    echo "==> Skipping installed cask $cask"
+    return 0
+  fi
+
   metadata="$(brew info --cask --json=v2 "$cask")"
 
   if cask_has_auto_updates "$metadata"; then
@@ -190,17 +195,11 @@ install_cask() {
     fi
   fi
 
-  if brew list --cask "$cask" >/dev/null 2>&1; then
-    echo "==> Skipping installed cask $cask"
-    return 0
-  fi
-
+  start_sudo_keepalive
   brew install --cask "$cask"
 }
 
 install_casks() {
-  start_sudo_keepalive
-
   while IFS= read -r cask; do
     [ -n "$cask" ] || continue
     install_cask "$cask"

--- a/home/run_once_before_10-install-homebrew-packages.sh
+++ b/home/run_once_before_10-install-homebrew-packages.sh
@@ -134,8 +134,8 @@ path_exists() {
   candidate=$1
 
   case "$candidate" in
-    '~/'*)
-      candidate="$HOME/${candidate#~/}"
+    \~/*)
+      candidate="$HOME/${candidate#\~/}"
       ;;
   esac
 
@@ -153,7 +153,7 @@ cask_app_is_installed() {
   found=1
   for app in $apps; do
     case "$app" in
-      /*|'~/'*)
+      /*|\~/*)
         if path_exists "$app"; then
           found=0
         fi

--- a/home/run_once_before_10-install-homebrew-packages.sh
+++ b/home/run_once_before_10-install-homebrew-packages.sh
@@ -8,6 +8,34 @@ if [ "$(uname -s)" != "Darwin" ]; then
   exit 0
 fi
 
+SUDO_KEEPALIVE_PID=
+
+stop_sudo_keepalive() {
+  if [ -n "$SUDO_KEEPALIVE_PID" ]; then
+    kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true
+    wait "$SUDO_KEEPALIVE_PID" 2>/dev/null || true
+    SUDO_KEEPALIVE_PID=
+  fi
+}
+
+start_sudo_keepalive() {
+  if [ "$(id -u)" -eq 0 ]; then
+    return 0
+  fi
+
+  echo "==> Requesting sudo once for Homebrew cask installation..."
+  sudo -v
+
+  (
+    while :; do
+      sleep 60
+      sudo -n -v || exit 0
+    done
+  ) &
+  SUDO_KEEPALIVE_PID=$!
+  trap stop_sudo_keepalive EXIT HUP INT TERM
+}
+
 if ! command -v brew >/dev/null 2>&1; then
   echo "==> Installing Homebrew..."
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -56,15 +84,66 @@ cask_has_auto_updates() {
   printf '%s\n' "$1" | jq -e '.casks[0].auto_updates == true' >/dev/null
 }
 
+cask_is_recorded_installed() {
+  printf '%s\n' "$1" | jq -e '
+    .casks[0].installed as $installed
+    | if $installed == null then false
+      elif ($installed | type) == "array" then ($installed | length > 0)
+      elif ($installed | type) == "string" then ($installed | length > 0)
+      else true
+      end
+  ' >/dev/null
+}
+
+cask_app_paths() {
+  printf '%s\n' "$1" | jq -r '
+    def path_values:
+      if type == "array" then
+        .[]
+        | if type == "string" then .
+          elif type == "object" then (.target? // empty)
+          else empty
+          end
+      elif type == "string" then .
+      elif type == "object" then (.target? // empty)
+      else empty
+      end;
+
+    (
+      (
+        .casks[0].artifacts[]?
+        | objects
+        | (
+            (.app? // empty | path_values),
+            (
+              .uninstall? // empty
+              | if type == "array" then .[] elif type == "object" then . else empty end
+              | objects
+              | .delete? // empty
+              | path_values
+            )
+          )
+      ),
+      (.casks[0].name[]? | select(type == "string") | . + ".app")
+    )
+    | select(test("\\.app$"))
+  ' | awk '!seen[$0]++'
+}
+
+path_exists() {
+  candidate=$1
+
+  case "$candidate" in
+    '~/'*)
+      candidate="$HOME/${candidate#~/}"
+      ;;
+  esac
+
+  [ -e "$candidate" ]
+}
+
 cask_app_is_installed() {
-  apps="$(
-    printf '%s\n' "$1" | jq -r '
-      .casks[0].artifacts[]
-      | objects
-      | .app? // empty
-      | if type == "array" then .[0] elif type == "string" then . else empty end
-    '
-  )"
+  apps="$(cask_app_paths "$1")"
 
   [ -n "$apps" ] || return 1
 
@@ -73,12 +152,21 @@ cask_app_is_installed() {
 '
   found=1
   for app in $apps; do
-    for app_dir in /Applications "$HOME/Applications"; do
-      if [ -e "$app_dir/$app" ]; then
-        found=0
-        break
-      fi
-    done
+    case "$app" in
+      /*|'~/'*)
+        if path_exists "$app"; then
+          found=0
+        fi
+        ;;
+      *)
+        for app_dir in /Applications "$HOME/Applications"; do
+          if [ -e "$app_dir/$app" ]; then
+            found=0
+            break
+          fi
+        done
+        ;;
+    esac
     [ "$found" -ne 0 ] || break
   done
   IFS=$old_ifs
@@ -88,16 +176,22 @@ cask_app_is_installed() {
 
 install_cask() {
   cask=$1
+  metadata="$(brew info --cask --json=v2 "$cask")"
+
+  if cask_has_auto_updates "$metadata"; then
+    if cask_is_recorded_installed "$metadata"; then
+      echo "==> Skipping self-updating cask $cask because Homebrew already records it as installed"
+      return 0
+    fi
+
+    if cask_app_is_installed "$metadata"; then
+      echo "==> Skipping self-updating cask $cask because its app is already installed"
+      return 0
+    fi
+  fi
 
   if brew list --cask "$cask" >/dev/null 2>&1; then
     echo "==> Skipping installed cask $cask"
-    return 0
-  fi
-
-  metadata="$(brew info --cask --json=v2 "$cask")"
-
-  if cask_has_auto_updates "$metadata" && cask_app_is_installed "$metadata"; then
-    echo "==> Skipping self-updating cask $cask because its app is already installed"
     return 0
   fi
 
@@ -105,6 +199,8 @@ install_cask() {
 }
 
 install_casks() {
+  start_sudo_keepalive
+
   while IFS= read -r cask; do
     [ -n "$cask" ] || continue
     install_cask "$cask"
@@ -155,6 +251,9 @@ visual-studio-code
 visual-studio-code@insiders
 zoom
 EOF
+
+  stop_sudo_keepalive
+  trap - EXIT HUP INT TERM
 }
 
 install_formulae

--- a/home/run_once_before_10-install-packages.ps1
+++ b/home/run_once_before_10-install-packages.ps1
@@ -1,23 +1,33 @@
-﻿# Windows: run_once_before_10-install-packages.ps1
-# winget でブートストラップに必要な最小パッケージをインストール
-# chezmoi が Windows で初回実行時のみ実行する
+# Windows: run_once_before_10-install-packages.ps1
+# Install minimal bootstrap packages with winget.
+# chezmoi should only run this script on Windows.
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-# winget で gitleaks をインストール（DSC 適用前の最低限のセキュリティツール）
+$isWindowsHost = [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+if (-not $isWindowsHost) {
+  Write-Warning 'Skipping Windows package installation because this host is not Windows.'
+  exit 0
+}
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+  throw 'winget was not found. Install App Installer or run this script from a Windows environment that provides winget.'
+}
+
 $packages = @(
   'ZedFreeman.Gitleaks'
   'junegunn.fzf'
 )
 
 foreach ($id in $packages) {
+  $escapedId = [regex]::Escape($id)
   $installed = winget list --id $id --accept-source-agreements 2>&1 |
-               Where-Object { $_ -match $id }
+               Where-Object { $_ -match $escapedId }
   if (-not $installed) {
-    Write-Output "==> $id をインストールします..."
+    Write-Output "==> Installing $id..."
     winget install --id $id --accept-package-agreements --accept-source-agreements
   } else {
-    Write-Output "==> $id は既にインストール済みです"
+    Write-Output "==> $id is already installed"
   }
 }

--- a/install.ps1
+++ b/install.ps1
@@ -27,7 +27,12 @@ if (-not (Get-Command chezmoi -ErrorAction SilentlyContinue)) {
 }
 
 Write-Output '==> Running chezmoi init & apply...'
-chezmoi init --apply kkamegawa
+$scriptRoot = $PSScriptRoot
+if (Test-Path (Join-Path $scriptRoot '.chezmoiroot')) {
+  chezmoi init --apply --source $scriptRoot
+} else {
+  chezmoi init --apply kkamegawa
+}
 
 $dscFile = "$(chezmoi source-path)\reference\windows\configuration.dsc.yaml"
 if (Test-Path $dscFile) {

--- a/install.ps1
+++ b/install.ps1
@@ -1,36 +1,42 @@
-﻿# Windows ブートストラップスクリプト
-# 使い方: ./install.ps1（PowerShell 7 以上を推奨）
+﻿# Windows bootstrap script.
+# Usage: ./install.ps1 (PowerShell 7 or later is recommended)
 #
-# 手順:
-#   1. chezmoi で dotfiles を適用
-#   2. WinGet Configuration で Windows 環境を構成
-#   3. mise でツールをインストール
-#   4. APM で Copilot CLI 設定を適用
+# Steps:
+#   1. Apply dotfiles with chezmoi.
+#   2. Configure the Windows environment with WinGet Configuration.
+#   3. Install tools with mise.
+#   4. Apply Copilot CLI configuration with APM.
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Write-Output "==> dotfiles セットアップを開始します (Windows)"
+$isWindowsHost = [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+if (-not $isWindowsHost) {
+  throw 'install.ps1 is Windows-only. Use ./install.sh on macOS, Linux, or WSL.'
+}
 
-# chezmoi がなければインストール
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+  throw 'winget was not found. Install App Installer before running the Windows bootstrap script.'
+}
+
+Write-Output '==> Starting dotfiles setup (Windows)'
+
 if (-not (Get-Command chezmoi -ErrorAction SilentlyContinue)) {
-  Write-Output "==> chezmoi をインストールします..."
+  Write-Output '==> Installing chezmoi...'
   winget install --id twpayne.chezmoi --accept-package-agreements --accept-source-agreements
 }
 
-# chezmoi init & apply
-Write-Output "==> chezmoi init & apply を実行します..."
+Write-Output '==> Running chezmoi init & apply...'
 chezmoi init --apply kkamegawa
 
-# WinGet Configuration で Windows 環境を構成
 $dscFile = "$(chezmoi source-path)\reference\windows\configuration.dsc.yaml"
 if (Test-Path $dscFile) {
-  Write-Output "==> WinGet Configuration を適用します..."
+  Write-Output '==> Applying WinGet Configuration...'
   winget configure -f $dscFile --accept-configuration-agreements
 }
 
 Write-Output ""
-Write-Output "==> セットアップ完了。続けて以下を実行してください:"
-Write-Output "    gh auth login"
-Write-Output "    mise install"
-Write-Output "    apm install"
+Write-Output '==> Setup complete. Run the following commands next:'
+Write-Output '    gh auth login'
+Write-Output '    mise install'
+Write-Output '    apm install'

--- a/install.sh
+++ b/install.sh
@@ -1,20 +1,27 @@
 #!/bin/sh
-# Linux / macOS / WSL ブートストラップスクリプト
-# 使い方: ./install.sh
+# Linux / macOS / WSL bootstrap script.
+# Usage: ./install.sh
 set -e
 
 OS="$(uname -s)"
-echo "==> dotfiles セットアップを開始します (OS: $OS)"
+case "$OS" in
+  Linux|Darwin)
+    ;;
+  *)
+    echo "==> install.sh supports Linux, macOS, and WSL only. Use install.ps1 on Windows." >&2
+    exit 1
+    ;;
+esac
 
-# chezmoi がなければインストール
+echo "==> Starting dotfiles setup (OS: $OS)"
+
 if ! command -v chezmoi >/dev/null 2>&1; then
-  echo "==> chezmoi をインストールします..."
+  echo "==> Installing chezmoi..."
   sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
 fi
 
-# chezmoi init & apply
-echo "==> chezmoi init & apply を実行します..."
+echo "==> Running chezmoi init & apply..."
 chezmoi init --apply kkamegawa
 
-echo "==> セットアップ完了。mise install を実行してください:"
+echo "==> Setup complete. Run mise install next:"
 echo "    cd ~ && mise install"

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,8 @@ echo "==> Starting dotfiles setup (OS: $OS)"
 if ! command -v chezmoi >/dev/null 2>&1; then
   echo "==> Installing chezmoi..."
   sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
+  PATH="$HOME/.local/bin:$PATH"
+  export PATH
 fi
 
 echo "==> Running chezmoi init & apply..."

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -e
 
 OS="$(uname -s)"
 SCRIPT_DIR=$(
-  CDPATH= cd -- "$(dirname -- "$0")" && pwd
+  CDPATH='' cd -- "$(dirname -- "$0")" && pwd
 )
 
 case "$OS" in

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,10 @@
 set -e
 
 OS="$(uname -s)"
+SCRIPT_DIR=$(
+  CDPATH= cd -- "$(dirname -- "$0")" && pwd
+)
+
 case "$OS" in
   Linux|Darwin)
     ;;
@@ -23,7 +27,11 @@ if ! command -v chezmoi >/dev/null 2>&1; then
 fi
 
 echo "==> Running chezmoi init & apply..."
-chezmoi init --apply kkamegawa
+if [ -f "$SCRIPT_DIR/.chezmoiroot" ]; then
+  chezmoi init --apply --source "$SCRIPT_DIR"
+else
+  chezmoi init --apply kkamegawa
+fi
 
 echo "==> Setup complete. Run mise install next:"
 echo "    cd ~ && mise install"


### PR DESCRIPTION
macOS could run Windows PowerShell package scripts when PowerShell was installed, which made the bootstrap attempt `winget` on non-Windows hosts. This PR separates OS-specific installer scripts at the chezmoi selection layer and adds runtime guards as a fallback.

## Summary

- Exclude Windows-only `.ps1` run scripts from non-Windows chezmoi applies, exclude shell run scripts on Windows, and limit Linux/macOS package installers to their target OS.
- Add explicit Windows and `winget` checks to Windows bootstrap/package scripts.
- Treat self-updating Homebrew casks as install-once: skip them when Homebrew records them as installed, and also detect existing `.app` bundles from cask metadata for apps installed outside Homebrew.
- Request sudo once before the Homebrew cask batch and keep the timestamp alive only while casks are installing.
- Add macOS chezmoi dry-run coverage to CI and update Homebrew docs in English and Japanese.

## Notes for reviewers

Zoom is a package-based cask and does not expose its app through the normal `app` artifact in Homebrew metadata. The cask detection also checks absolute `.app` paths from uninstall metadata so already-installed Zoom is skipped instead of being reinstalled.

Closes #8