### PR TITLE
Fix chezmoi init platform data handling

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,7 +66,10 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: chezmoi dry-run (Linux)
         run: |
-          chezmoi init --source "$GITHUB_WORKSPACE" --dry-run --verbose
+          dest="$RUNNER_TEMP/chezmoi-home"
+          config="$dest/.config/chezmoi/chezmoi.toml"
+          mkdir -p "$(dirname "$config")"
+          chezmoi init --source "$GITHUB_WORKSPACE" --config-path "$config" --destination "$dest" --apply --dry-run --verbose --no-tty
 
   chezmoi-dry-run-macos:
     name: chezmoi dry-run (macOS)
@@ -79,7 +82,10 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: chezmoi dry-run (macOS)
         run: |
-          chezmoi init --source "$GITHUB_WORKSPACE" --dry-run --verbose
+          dest="$RUNNER_TEMP/chezmoi-home"
+          config="$dest/.config/chezmoi/chezmoi.toml"
+          mkdir -p "$(dirname "$config")"
+          chezmoi init --source "$GITHUB_WORKSPACE" --config-path "$config" --destination "$dest" --apply --dry-run --verbose --no-tty
 
   chezmoi-dry-run-windows:
     name: chezmoi dry-run (Windows)
@@ -96,7 +102,10 @@ jobs:
       - name: chezmoi dry-run (Windows)
         shell: pwsh
         run: |
-          chezmoi init --source "$env:GITHUB_WORKSPACE" --dry-run --verbose
+          $dest = Join-Path $env:RUNNER_TEMP 'chezmoi-home'
+          $config = Join-Path $dest '.config\chezmoi\chezmoi.toml'
+          New-Item -ItemType Directory -Force -Path (Split-Path $config) | Out-Null
+          chezmoi init --source "$env:GITHUB_WORKSPACE" --config-path "$config" --destination "$dest" --apply --dry-run --verbose --no-tty
 
   winget-config-validate:
     name: winget configure validate

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,7 +69,14 @@ jobs:
           dest="$RUNNER_TEMP/chezmoi-home"
           config="$dest/.config/chezmoi/chezmoi.toml"
           mkdir -p "$(dirname "$config")"
-          chezmoi init --source "$GITHUB_WORKSPACE" --config-path "$config" --destination "$dest" --apply --dry-run --verbose --no-tty
+          chezmoi init \
+            --source "$GITHUB_WORKSPACE" \
+            --config-path "$config" \
+            --destination "$dest" \
+            --apply \
+            --dry-run \
+            --verbose \
+            --no-tty
 
   chezmoi-dry-run-macos:
     name: chezmoi dry-run (macOS)
@@ -85,7 +92,14 @@ jobs:
           dest="$RUNNER_TEMP/chezmoi-home"
           config="$dest/.config/chezmoi/chezmoi.toml"
           mkdir -p "$(dirname "$config")"
-          chezmoi init --source "$GITHUB_WORKSPACE" --config-path "$config" --destination "$dest" --apply --dry-run --verbose --no-tty
+          chezmoi init \
+            --source "$GITHUB_WORKSPACE" \
+            --config-path "$config" \
+            --destination "$dest" \
+            --apply \
+            --dry-run \
+            --verbose \
+            --no-tty
 
   chezmoi-dry-run-windows:
     name: chezmoi dry-run (Windows)
@@ -105,7 +119,20 @@ jobs:
           $dest = Join-Path $env:RUNNER_TEMP 'chezmoi-home'
           $config = Join-Path $dest '.config\chezmoi\chezmoi.toml'
           New-Item -ItemType Directory -Force -Path (Split-Path $config) | Out-Null
-          chezmoi init --source "$env:GITHUB_WORKSPACE" --config-path "$config" --destination "$dest" --apply --dry-run --verbose --no-tty
+          $chezmoiArgs = @(
+            'init'
+            '--source'
+            "$env:GITHUB_WORKSPACE"
+            '--config-path'
+            "$config"
+            '--destination'
+            "$dest"
+            '--apply'
+            '--dry-run'
+            '--verbose'
+            '--no-tty'
+          )
+          chezmoi @chezmoiArgs
 
   winget-config-validate:
     name: winget configure validate

--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -15,7 +15,7 @@
 {{ else if .isWSL }}
   program = /mnt/c/Users/{{ .windowsUser }}/AppData/Local/1Password/app/8/op-ssh-sign-wsl.exe
 {{ else if .isWindows }}
-  program = C:/Users/{{ .windowsUser }}/AppData/Local/1Password/app/8/op-ssh-sign.exe
+  program = {{ .chezmoi.homeDir }}/AppData/Local/1Password/app/8/op-ssh-sign.exe
 {{ else if .isLinux }}
   program = /opt/1Password/op-ssh-sign
 {{ end }}


### PR DESCRIPTION
## Why
Fresh Windows `chezmoi init --apply kkamegawa` fails because `.gitconfig` used `.windowsUser` in the native Windows branch, but that data key is only populated for WSL. As a result, the GitHub-backed init path still errors before `.gitconfig` can be rendered.

## What changed
- use `.chezmoi.homeDir` for the native Windows 1Password signer path in `dot_gitconfig.tmpl`
- keep `.windowsUser` only in the WSL branch, where it is actually defined and needed
- update the CI `chezmoi init` dry-runs to use `--apply` with an isolated destination and config path so fresh-init rendering is exercised instead of reusing existing local state

## Notes
- I audited the custom chezmoi data references and did not find another missing-key risk of the same kind
- this also explains why the local worktree source succeeded while `chezmoi init --apply kkamegawa` still failed before the fix was pushed

Closes #10