### PR TITLE
Fix deprecated Git fsmonitor warning on Windows

### DIFF
--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -36,6 +36,9 @@
   autocrlf = {{ if .isWindows }}true{{ else }}input{{ end }}
   safecrlf = warn
   hooksPath = ~/.config/git/hooks
+{{- if .isWindows }}
+  fsmonitor = true
+{{- end }}
 
 [init]
   defaultBranch = main


### PR DESCRIPTION
Closes #12.

`chezmoi apply` currently surfaces a deprecated Git warning on Windows because Git for Windows still provides `core.useBuiltinFSMonitor=true` at the system level. This change makes the dotfiles-managed global Git config explicitly set `core.fsmonitor=true`, which uses the supported setting and keeps the warning out of normal apply flows.

## What changed
- add `core.fsmonitor = true` to the Windows branch of `home/dot_gitconfig.tmpl`
- keep the change scoped to Windows so non-Windows environments keep their current behavior

## Notes
- the warning source is Git for Windows system config, not this repository
- this PR fixes it at the user config layer managed by chezmoi

## Validation
- rendered the template on Windows and confirmed it emits `core.fsmonitor = true`
- ran Git with the rendered config as the global config and confirmed the warning no longer appears