### PR TITLE
chore: update mise tool-spec watch baseline to v2026.5.8

### DIFF
--- a/reference/ci/tool-spec-watch.json
+++ b/reference/ci/tool-spec-watch.json
@@ -30,7 +30,7 @@
       "displayName": "mise",
       "kind": "github-release",
       "repo": "jdx/mise",
-      "knownVersion": "v2026.4.20",
+      "knownVersion": "v2026.5.8",
       "impactFiles": [
         ".mise.toml",
         "dot_config\\mise\\config.toml.tmpl",


### PR DESCRIPTION
Upstream `mise` released `v2026.5.8`, and the tool-spec watch issue was triggered for this repository. This PR updates the tracked baseline so future alerts are based on the latest reviewed release.

## What changed
- Updated `reference/ci/tool-spec-watch.json` for `mise`:
  - `knownVersion`: `v2026.4.20` -> `v2026.5.8`

## Notes
- Repository usage was reviewed for the deprecation signal in `v2026.5.8` (`env_file` / `MISE_ENV_FILE`), and no migration changes were needed in this repo.

Fixes: #19