### PR TITLE
[update]: Update APM profile setup and output messages

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -1,5 +1,6 @@
 # OS-specific exclusions.
 {{ if ne .chezmoi.os "windows" }}
+60-setup-apm-profile.ps1
 05-setup-mise-path.ps1
 10-install-packages.ps1
 50-import-vs-settings.ps1

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -6,6 +6,7 @@
 {{ end }}
 
 {{ if eq .chezmoi.os "windows" }}
+60-setup-apm-profile.sh
 10-install-homebrew-packages.sh
 10-install-packages.sh
 10-setup-git-hooks.sh

--- a/home/run_once_after_60-setup-apm-profile.ps1
+++ b/home/run_once_after_60-setup-apm-profile.ps1
@@ -67,7 +67,7 @@ function Set-DirectoryLink {
     } elseif ($item.PSIsContainer) {
       $children = Get-ChildItem -LiteralPath $LinkPath -Force
       if ($children.Count -gt 0) {
-        Write-Output "==> Skip linking $LinkPath because the directory is not empty"
+        Write-Warning "==> Skip linking $LinkPath because the directory is not empty"
         return
       }
 

--- a/home/run_once_after_60-setup-apm-profile.ps1
+++ b/home/run_once_after_60-setup-apm-profile.ps1
@@ -67,7 +67,7 @@ function Set-DirectoryLink {
     } elseif ($item.PSIsContainer) {
       $children = Get-ChildItem -LiteralPath $LinkPath -Force
       if ($children.Count -gt 0) {
-        Write-Warning "Skip linking $LinkPath because the directory is not empty"
+        Write-Output "==> Skip linking $LinkPath because the directory is not empty"
         return
       }
 


### PR DESCRIPTION
Added the APM profile script to the .chezmoiignore for Windows and improved the output message for directory linking to provide clearer feedback when directories are not empty.