### PR TITLE
Update macOS bootstrap packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ apt ベースの Linux / WSL では、ブートストラップ中に PowerShell 
 `Az` / `Microsoft.Entra` / `Microsoft.Graph` モジュールもセットアップします。
 macOS の PowerShell 7 は Intune で管理します。
 
+macOS では `home/run_once_before_10-install-homebrew-packages.sh` が Homebrew パッケージを管理します。
+Azure CLI は Microsoft Learn の preview 手順に合わせて `azure/azure-cli` tap の
+`azure-cli-preview` cask を使用し、Docker は `docker-desktop` cask を使用します。
+
 ### Windows
 
 ```powershell
@@ -110,6 +114,7 @@ Get-ChildItem "$HOME/.config/apm"
 ## ドキュメント
 
 - [アーキテクチャと設計判断](docs/architecture.md)
+- [Homebrew パッケージ管理](docs/homebrew_ja.md)
 - [日常操作ガイド](docs/operations.md)
 - [Windows 固有の設定](docs/windows.md)
 - [トラブルシューティング](docs/troubleshooting.md)

--- a/docs/homebrew_en.md
+++ b/docs/homebrew_en.md
@@ -12,6 +12,15 @@ For casks marked `auto_updates` in Homebrew metadata, the bootstrap treats the f
 
 This keeps first-time setup behavior intact for new machines while avoiding repeated Homebrew work for apps that manage their own updates. Casks that are missing continue to use the normal `brew install --cask` path.
 
+## Azure CLI preview cask
+
+On macOS, this repository installs Azure CLI with the preview Homebrew cask flow from Microsoft Learn instead of the Homebrew core formula.
+
+- Tap: `azure/azure-cli`
+- Cask: `azure-cli-preview`
+
+The bootstrap does not install the `azure-cli` formula during the preview phase, which avoids conflicts with the cask-based installation model.
+
 ## Sudo handling for casks
 
 Formula installation does not keep sudo alive. Immediately before cask installation starts, the bootstrap runs `sudo -v` once and keeps that sudo timestamp active only while the cask batch is running. This avoids repeated password prompts from cask installers without leaving a long-lived sudo keepalive process after the bootstrap finishes.

--- a/docs/homebrew_ja.md
+++ b/docs/homebrew_ja.md
@@ -12,6 +12,15 @@ Homebrew メタデータで `auto_updates` として扱われる cask は、初�
 
 これにより、新しいマシンでの初回セットアップは維持しつつ、自分で更新機能を持つアプリに対する Homebrew の再処理を避けます。未インストールの cask は、従来どおり `brew install --cask` を実行します。
 
+## Azure CLI preview cask
+
+macOS では、Azure CLI を Homebrew core の formula ではなく、Microsoft Learn の preview 手順に沿った Homebrew cask 方式でインストールします。
+
+- tap: `azure/azure-cli`
+- cask: `azure-cli-preview`
+
+preview 期間中は `azure-cli` formula をインストールせず、cask ベースのインストール方式と競合しないようにしています。
+
 ## cask の sudo 処理
 
 Formula のインストール中は sudo を維持しません。cask のインストールを開始する直前に `sudo -v` を一度だけ実行し、cask の一括処理が続いている間だけ sudo のタイムスタンプを維持します。これにより、cask インストーラーによるパスワードの再入力を避けつつ、ブートストラップ完了後に sudo 維持プロセスを残しません。

--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -76,3 +76,12 @@
 [credential "https://gist.github.com"]
   helper =
   helper = {{ $ghCredHelper }}
+
+{{- if .isMac }}
+[credential]
+  helper =
+  helper = /usr/local/share/gcm-core/git-credential-manager
+
+[credential "https://dev.azure.com"]
+  useHttpPath = true
+{{- end }}

--- a/home/run_once_before_10-install-homebrew-packages.sh
+++ b/home/run_once_before_10-install-homebrew-packages.sh
@@ -58,13 +58,12 @@ install_formulae() {
   done <<'EOF'
 ansible
 ansible-lint
-azure-cli
+gitleaks
 azure/azd/azd
 azure/bicep/bicep
 azure/functions/azure-functions-core-tools@4
 cmake
 curl
-docker-completion
 docker-squash
 gh
 git
@@ -72,8 +71,10 @@ git-lfs
 hashicorp/tap/packer
 jq
 komac
+microsoft/apm/apm
 micro
 oh-my-posh
+playwright-cli
 starship
 termscp
 uv
@@ -173,6 +174,12 @@ EOF
 install_cask() {
   cask=$1
 
+  case "$cask" in
+    azure-cli-preview)
+      brew tap azure/azure-cli
+      ;;
+  esac
+
   if brew list --cask "$cask" >/dev/null 2>&1; then
     echo "==> Skipping installed cask $cask"
     return 0
@@ -207,6 +214,7 @@ install_casks() {
 1password
 1password-cli
 adobe-creative-cloud
+azure-cli-preview
 bing-wallpaper
 blender
 cleanshot
@@ -250,6 +258,7 @@ microsoft-edge
 microsoft-edge@beta
 microsoft-edge@dev
 microsoft-openjdk
+microsoft-openjdk@17
 microsoft-openjdk@21
 spotify
 visual-studio-code


### PR DESCRIPTION
Update the macOS bootstrap package list and related docs to match the current local environment.

- add managed Homebrew packages used on the current Mac
- switch Azure CLI to the preview cask flow with the required `azure/azure-cli` tap
- keep Docker managed via `docker-desktop`
- restore macOS-specific Git credential settings for GCM and Azure DevOps
- document the Homebrew package management changes

Closes #27