### PR TITLE
fix: use mise tools.python.path template for UV_PYTHON

### DIFF
--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -15,5 +15,7 @@ python = ['3.13', '3.11', '3.12']
 # mise 管理の Python を uv のデフォルト Python として使う
 # NOTE: 二重波括弧は mise 自身のテンプレート構文であり、chezmoi の Go テンプレートではない。
 # chezmoi にリテラルとして出力させるためエスケープしている。
-UV_PYTHON = "{{ "{{" }} mise exec python -- python --version | head -c 20 {{ "}}" }}"
+# `tools.python.path` は mise が公式に提供するテンプレート変数で、シェルコマンドの
+# パイプ（head 等）を使わないため Windows でも壊れない。
+UV_PYTHON = { value = "{{ "{{" }} tools.python.path {{ "}}" }}", tools = true }
 


### PR DESCRIPTION
## Summary
- `home/dot_config/mise/config.toml.tmpl` embedded a raw shell pipeline (`mise exec python -- python --version | head -c 20`) directly inside mise's tera `{{ }}` template, which is invalid tera syntax and broke `chezmoi update` / `mise install` with a template parse error.
- `head` also doesn't exist on Windows, so the command would have failed regardless of the syntax fix.
- Replaced it with mise's built-in `tools.python.path` template variable, which requires no shell execution and is officially documented.

Closes #33

## Test plan
- [x] `chezmoi execute-template < home/dot_config/mise/config.toml.tmpl` renders `UV_PYTHON = { value = "{{ tools.python.path }}", tools = true }` correctly
- [ ] `chezmoi update` / `mise install` no longer reports the template parse error (to be verified by reviewer/CI)