### PR TITLE
fix: index tools.python array in UV_PYTHON mise template

### DIFF
--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -15,7 +15,8 @@ python = ['3.13', '3.11', '3.12']
 # mise 管理の Python を uv のデフォルト Python として使う
 # NOTE: 二重波括弧は mise 自身のテンプレート構文であり、chezmoi の Go テンプレートではない。
 # chezmoi にリテラルとして出力させるためエスケープしている。
-# `tools.python.path` は mise が公式に提供するテンプレート変数で、シェルコマンドの
-# パイプ（head 等）を使わないため Windows でも壊れない。
-UV_PYTHON = { value = "{{ "{{" }} tools.python.path {{ "}}" }}", tools = true }
+# `tools.python` は上の [tools] で複数バージョンを指定しているため配列になる。
+# `.path` を直接参照するとキーが見つからずレンダリングに失敗するため、
+# 先頭要素（最初に指定したバージョン）を明示的にインデックス参照する。
+UV_PYTHON = { value = "{{ "{{" }} tools.python[0].path {{ "}}" }}", tools = true }
 


### PR DESCRIPTION
## Summary
- `mise` exposes `tools.<name>` as an array when multiple versions are configured for a tool. `home/dot_config/mise/config.toml.tmpl` declares `python = ['3.13', '3.11', '3.12']`, so `tools.python.path` (introduced in #34) fails with `Variable 'tools.python.path' not found in context`.
- Index the array (`tools.python[0].path`) to pick the first-listed version (3.13) as the `uv` default Python.

Fixes #35

## Test plan
- [x] Reproduced the error locally with `mise env` against the current global config.
- [x] Confirmed `tools.python[0].path` resolves correctly via `mise env` (`UV_PYTHON` set to the 3.13 install path).
- [x] Verified end-to-end by fetching this branch into the actual `chezmoi` source clone and running `chezmoi apply --exclude=scripts --force`; the regenerated `~/.config/mise/config.toml` renders without error.