### PR TITLE
add: Claude Code context window hooks (PostCompact, UserPromptSubmit, statusLine)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Default: auto-detect text and normalize to LF in repo
+* text=auto
+
+# Shell scripts must stay LF to avoid shebang and syntax errors
+*.sh text eol=lf
+*.mjs text eol=lf
+
+# C# source files: LF in repo, checkout as-is on each platform
+*.cs text eol=lf
+
+# PowerShell: keep CRLF (matches .editorconfig)
+*.ps1 text eol=crlf
+*.psm1 text eol=crlf
+*.psd1 text eol=crlf
+
+# Binary files: do not modify
+*.png binary
+*.jpg binary
+*.ico binary
+*.zip binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,10 +5,10 @@
 *.sh text eol=lf
 *.mjs text eol=lf
 
-# C# source files: LF in repo, checkout as-is on each platform
+# C# source files: normalize to LF and enforce LF in the working tree
 *.cs text eol=lf
 
-# PowerShell: keep CRLF (matches .editorconfig)
+# PowerShell: normalize to LF in the repo, enforce CRLF in the working tree (matches .editorconfig)
 *.ps1 text eol=crlf
 *.psm1 text eol=crlf
 *.psd1 text eol=crlf

--- a/home/dot_claude/hooks/compaction-recovery.cs
+++ b/home/dot_claude/hooks/compaction-recovery.cs
@@ -1,0 +1,31 @@
+using System.Text.Json.Nodes;
+
+// PostCompact hook (.NET 10 file-based program)
+// Saves compact_summary for recovery and clears the 60%-warning marker.
+
+try
+{
+    var input = await Console.In.ReadToEndAsync();
+    var data = JsonNode.Parse(input.Length > 0 ? input : "{}");
+    var sessionId = data?["session_id"]?.GetValue<string>() ?? "unknown";
+    var summary = data?["compact_summary"]?.GetValue<string>() ?? string.Empty;
+
+    var stateDir = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".claude", "hooks-state");
+    Directory.CreateDirectory(stateDir);
+
+    if (!string.IsNullOrWhiteSpace(summary))
+    {
+        await File.WriteAllTextAsync(
+            Path.Combine(stateDir, $"{sessionId}.summary"), summary);
+    }
+
+    var warnFile = Path.Combine(stateDir, $"{sessionId}.warned");
+    if (File.Exists(warnFile))
+        File.Delete(warnFile);
+}
+catch
+{
+    // Never block the user's flow
+}

--- a/home/dot_claude/hooks/statusline.mjs
+++ b/home/dot_claude/hooks/statusline.mjs
@@ -24,7 +24,7 @@ function main() {
 
     const data = JSON.parse(raw);
     const model = data.model?.display_name ?? 'Claude';
-    const pct = Math.round(data.context_window?.used_percentage ?? 0);
+    const pct = Math.max(0, Math.min(100, Math.round(+data.context_window?.used_percentage || 0)));
     const cwd = data.cwd ?? '';
     const sessionId = data.session_id ?? 'unknown';
 

--- a/home/dot_claude/hooks/statusline.mjs
+++ b/home/dot_claude/hooks/statusline.mjs
@@ -1,0 +1,47 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+/**
+ * statusLine script for Claude Code.
+ * Receives JSON session data on stdin, outputs a formatted context bar.
+ * Creates ~/.claude/hooks-state/{session_id}.warned when context >= 60%.
+ */
+
+function buildBar(pct, width) {
+  const filled = Math.round((pct / 100) * width);
+  const empty = width - filled;
+  const color =
+    pct >= 80 ? '\x1b[31m' : pct >= 60 ? '\x1b[33m' : '\x1b[32m';
+  const reset = '\x1b[0m';
+  return `${color}[${'█'.repeat(filled)}${'░'.repeat(empty)}]${reset}`;
+}
+
+function main() {
+  try {
+    const raw = readFileSync(0, 'utf8').trim();
+    if (!raw) return;
+
+    const data = JSON.parse(raw);
+    const model = data.model?.display_name ?? 'Claude';
+    const pct = Math.round(data.context_window?.used_percentage ?? 0);
+    const cwd = data.cwd ?? '';
+    const sessionId = data.session_id ?? 'unknown';
+
+    // Write warned marker once when context reaches 60%
+    const stateDir = join(homedir(), '.claude', 'hooks-state');
+    mkdirSync(stateDir, { recursive: true });
+    const warnFile = join(stateDir, `${sessionId}.warned`);
+    if (pct >= 60 && !existsSync(warnFile)) {
+      writeFileSync(warnFile, new Date().toISOString(), 'utf8');
+    }
+
+    const dirName = cwd.split(/[/\\]/).pop() || cwd;
+    const bar = buildBar(pct, 20);
+    process.stdout.write(`[${model}] 📁 ${dirName} | ${bar} ${pct}%\n`);
+  } catch {
+    // Silent failure: never crash the status line
+  }
+}
+
+main();

--- a/home/dot_claude/hooks/userpromptsubmit-compact-prep-reminder.cs
+++ b/home/dot_claude/hooks/userpromptsubmit-compact-prep-reminder.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Nodes;
+
+// UserPromptSubmit hook: compact prep reminder (.NET 10 file-based program)
+// If the statusLine script has set a warned marker (context >= 60%), inject
+// a reminder to run /compact before the context window fills up.
+
+try
+{
+    var input = await Console.In.ReadToEndAsync();
+    var data = JsonNode.Parse(input.Length > 0 ? input : "{}");
+    var sessionId = data?["session_id"]?.GetValue<string>() ?? "unknown";
+
+    var stateDir = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".claude", "hooks-state");
+    var warnFile = Path.Combine(stateDir, $"{sessionId}.warned");
+
+    if (!File.Exists(warnFile))
+        return;
+
+    var output = new JsonObject
+    {
+        ["hookSpecificOutput"] = new JsonObject
+        {
+            ["hookEventName"] = "UserPromptSubmit",
+            ["additionalContext"] =
+                "⚠️ Context window usage has reached 60% or more. " +
+                "Consider running /compact soon to avoid losing context."
+        }
+    };
+    Console.Write(output.ToJsonString());
+}
+catch
+{
+    // Never block the user's flow
+}

--- a/home/dot_claude/hooks/userpromptsubmit-compaction-recovery.cs
+++ b/home/dot_claude/hooks/userpromptsubmit-compaction-recovery.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Nodes;
+
+// UserPromptSubmit hook: compaction recovery (.NET 10 file-based program)
+// If a compact_summary was saved by the PostCompact hook, inject it as
+// additionalContext so Claude knows the prior session state.
+
+try
+{
+    var input = await Console.In.ReadToEndAsync();
+    var data = JsonNode.Parse(input.Length > 0 ? input : "{}");
+    var sessionId = data?["session_id"]?.GetValue<string>() ?? "unknown";
+
+    var stateDir = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".claude", "hooks-state");
+    var summaryFile = Path.Combine(stateDir, $"{sessionId}.summary");
+
+    if (!File.Exists(summaryFile))
+        return;
+
+    var summary = await File.ReadAllTextAsync(summaryFile);
+    File.Delete(summaryFile); // One-shot: inject once then discard
+
+    var output = new JsonObject
+    {
+        ["hookSpecificOutput"] = new JsonObject
+        {
+            ["hookEventName"] = "UserPromptSubmit",
+            ["additionalContext"] =
+                "[Post-compact recovery] The context window was compacted. " +
+                $"Summary of the previous session:\n{summary}"
+        }
+    };
+    Console.Write(output.ToJsonString());
+}
+catch
+{
+    // Never block the user's flow
+}

--- a/home/dot_claude/hooks/userpromptsubmit-compaction-recovery.cs
+++ b/home/dot_claude/hooks/userpromptsubmit-compaction-recovery.cs
@@ -19,7 +19,6 @@ try
         return;
 
     var summary = await File.ReadAllTextAsync(summaryFile);
-    File.Delete(summaryFile); // One-shot: inject once then discard
 
     var output = new JsonObject
     {
@@ -32,6 +31,8 @@ try
         }
     };
     Console.Write(output.ToJsonString());
+
+    File.Delete(summaryFile); // One-shot: inject once then discard
 }
 catch
 {

--- a/home/dot_claude/settings.json.tmpl
+++ b/home/dot_claude/settings.json.tmpl
@@ -123,7 +123,47 @@
           }
         ]
       }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "dotnet",
+            "args": ["__CLAUDE_HOME__/hooks/compaction-recovery.cs"],
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "dotnet",
+            "args": ["__CLAUDE_HOME__/hooks/userpromptsubmit-compaction-recovery.cs"],
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "dotnet",
+            "args": ["__CLAUDE_HOME__/hooks/userpromptsubmit-compact-prep-reminder.cs"],
+            "timeout": 10
+          }
+        ]
+      }
     ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "node",
+    "args": ["__CLAUDE_HOME__/hooks/statusline.mjs"],
+    "timeout": 5
   },
   "sandbox": {
     "enabled": true,


### PR DESCRIPTION
## Summary

Implements Claude Code context window management hooks to address review feedback in #38.

## Changes

### New hooks

| File | Type | Purpose |
|------|------|---------|
| `home/dot_claude/hooks/statusline.mjs` | Node.js | Displays colored context bar; writes `warned` marker at ≥60% usage |
| `home/dot_claude/hooks/compaction-recovery.cs` | .NET 10 | PostCompact: saves `compact_summary` to marker file, clears `warned` |
| `home/dot_claude/hooks/userpromptsubmit-compaction-recovery.cs` | .NET 10 | UserPromptSubmit: injects prior-session summary into `additionalContext` (one-shot) |
| `home/dot_claude/hooks/userpromptsubmit-compact-prep-reminder.cs` | .NET 10 | UserPromptSubmit: reminds user to `/compact` when `warned` marker exists |

### Modified files

- `home/dot_claude/settings.json.tmpl`: wires `PostCompact`, `UserPromptSubmit`, and `statusLine`
- `.gitattributes`: enforces LF on `.sh`, `.mjs`, `.cs`; CRLF on `.ps1`

## How it works

```
statusLine (after each message)
  └─ reads context_window.used_percentage
  └─ if >= 60%: writes ~/.claude/hooks-state/{session_id}.warned

UserPromptSubmit (before each user prompt)
  ├─ userpromptsubmit-compact-prep-reminder.cs
  │   └─ if warned marker exists → injects /compact reminder into additionalContext
  └─ userpromptsubmit-compaction-recovery.cs
      └─ if summary file exists → injects session summary into additionalContext (then deletes file)

PostCompact (after compaction)
  └─ compaction-recovery.cs
      ├─ saves compact_summary to ~/.claude/hooks-state/{session_id}.summary
      └─ deletes warned marker
```

## Review issues addressed

1. ✅ **statusLine now wired** — `statusline.mjs` is connected via `settings.json.tmpl`'s `statusLine` key
2. ✅ **No execute-permission issues** — `.cs` and `.mjs` run via `dotnet`/`node`; no chmod needed
3. ✅ **Reminder is persistent** — warned marker stays until `/compact` fires; user sees reminder on every prompt after 60%

## Platform support

Cross-platform (Windows / macOS / WSL2):
- Node.js for statusLine (lightweight, already required)
- .NET 10 file-based programs for hooks (no jq dependency, no shell quoting issues)
- Marker files in `~/.claude/hooks-state/` (not OS temp, survives across sessions)

Closes #38