### PR TITLE
Add cleanup task for old PowerShell modules

### DIFF
--- a/docs/powershell-module-cleanup.md
+++ b/docs/powershell-module-cleanup.md
@@ -1,0 +1,41 @@
+# PowerShell module cleanup
+
+The global mise configuration includes a cleanup task for old PowerShell module versions.
+It runs the C# file-based app at `~/.config/mise/oldpowershellmodule.cs`.
+
+## Targets
+
+The task keeps the latest installed version and removes older versions for modules matching:
+
+- `Az*`
+- `Microsoft.Entra*`
+- `Microsoft.Graph*`
+
+The app uses PowerShell module metadata to find each module location, so it works with the standard user module locations on both Windows and macOS.
+
+## Run on macOS
+
+```bash
+# Preview removals.
+mise run clean-old-pwsh-modules-dry-run
+
+# Remove old versions.
+mise run clean-old-pwsh-modules
+```
+
+## Run on Windows
+
+```powershell
+# Preview removals.
+mise run clean-old-pwsh-modules-dry-run
+
+# Remove old versions.
+mise run clean-old-pwsh-modules
+```
+
+## Requirements
+
+- .NET SDK 10 or later
+- PowerShell 7
+- PowerShellGet-compatible `Get-InstalledModule` and `Uninstall-Module` commands
+

--- a/docs/powershell-module-cleanup.md
+++ b/docs/powershell-module-cleanup.md
@@ -11,7 +11,8 @@ The task keeps the latest installed version and removes older versions for modul
 - `Microsoft.Entra*`
 - `Microsoft.Graph*`
 
-The app uses PowerShell module metadata to find each module location, so it works with the standard user module locations on both Windows and macOS.
+The app scans `PSModulePath` plus common PowerShell module directories, then detects installed versions from version folder names.
+This works with the standard user module locations on both Windows and macOS.
 
 ## Run on macOS
 
@@ -37,5 +38,4 @@ mise run clean-old-pwsh-modules
 
 - .NET SDK 10 or later
 - PowerShell 7
-- PowerShellGet-compatible `Get-InstalledModule` and `Uninstall-Module` commands
-
+- A PowerShellGet-compatible `Uninstall-Module` command

--- a/docs/powershell-module-cleanup_ja.md
+++ b/docs/powershell-module-cleanup_ja.md
@@ -11,7 +11,8 @@
 - `Microsoft.Entra*`
 - `Microsoft.Graph*`
 
-アプリは PowerShell モジュールのメタデータから各モジュールの場所を取得するため、Windows と macOS の標準ユーザーモジュール配置で動作します。
+アプリは `PSModulePath` と一般的な PowerShell モジュール配置を走査し、バージョンフォルダー名からインストール済みバージョンを検出します。
+そのため、Windows と macOS の標準ユーザーモジュール配置で動作します。
 
 ## macOS での実行
 
@@ -37,5 +38,4 @@ mise run clean-old-pwsh-modules
 
 - .NET SDK 10 以降
 - PowerShell 7
-- PowerShellGet 互換の `Get-InstalledModule` と `Uninstall-Module` コマンド
-
+- PowerShellGet 互換の `Uninstall-Module` コマンド

--- a/docs/powershell-module-cleanup_ja.md
+++ b/docs/powershell-module-cleanup_ja.md
@@ -1,0 +1,41 @@
+# PowerShell モジュールのクリーンアップ
+
+グローバル mise 設定には、古い PowerShell モジュールバージョンを削除するタスクがあります。
+このタスクは `~/.config/mise/oldpowershellmodule.cs` の C# file-based app を実行します。
+
+## 対象
+
+タスクは最新バージョンを残し、次のパターンに一致するモジュールの古いバージョンを削除します。
+
+- `Az*`
+- `Microsoft.Entra*`
+- `Microsoft.Graph*`
+
+アプリは PowerShell モジュールのメタデータから各モジュールの場所を取得するため、Windows と macOS の標準ユーザーモジュール配置で動作します。
+
+## macOS での実行
+
+```bash
+# 削除対象を確認します。
+mise run clean-old-pwsh-modules-dry-run
+
+# 古いバージョンを削除します。
+mise run clean-old-pwsh-modules
+```
+
+## Windows での実行
+
+```powershell
+# 削除対象を確認します。
+mise run clean-old-pwsh-modules-dry-run
+
+# 古いバージョンを削除します。
+mise run clean-old-pwsh-modules
+```
+
+## 必要なもの
+
+- .NET SDK 10 以降
+- PowerShell 7
+- PowerShellGet 互換の `Get-InstalledModule` と `Uninstall-Module` コマンド
+

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -8,8 +8,17 @@ env_file = '.env'
 [tools]
 node = "lts"
 npm = "latest"
+dotnet = "10"
 python = ['3.13', '3.11', '3.12']
 "npm:@vscode/vsce" = "latest"
+
+[tasks.clean-old-pwsh-modules]
+description = "Remove old Azure, Microsoft Entra, and Microsoft Graph PowerShell module versions."
+run = 'dotnet run --file "{{ "{{" }} config_root {{ "}}" }}/oldpowershellmodule.cs"'
+
+[tasks.clean-old-pwsh-modules-dry-run]
+description = "Show old PowerShell module versions that would be removed."
+run = 'dotnet run --file "{{ "{{" }} config_root {{ "}}" }}/oldpowershellmodule.cs" -- --dry-run'
 
 [env]
 # mise 管理の Python を uv のデフォルト Python として使う

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -15,7 +15,8 @@ python = ['3.13', '3.11', '3.12']
 # mise 管理の Python を uv のデフォルト Python として使う
 # NOTE: 二重波括弧は mise 自身のテンプレート構文であり、chezmoi の Go テンプレートではない。
 # chezmoi にリテラルとして出力させるためエスケープしている。
-# `tools.python.path` は mise が公式に提供するテンプレート変数で、シェルコマンドの
-# パイプ（head 等）を使わないため Windows でも壊れない。
-UV_PYTHON = { value = "{{ "{{" }} tools.python.path {{ "}}" }}", tools = true }
+# `tools.python` は上の [tools] で複数バージョンを指定しているため配列になる。
+# `.path` を直接参照するとキーが見つからずレンダリングに失敗するため、
+# 先頭要素（最初に指定したバージョン）を明示的にインデックス参照する。
+UV_PYTHON = { value = "{{ "{{" }} tools.python[0].path {{ "}}" }}", tools = true }
 

--- a/home/dot_config/mise/oldpowershellmodule.cs
+++ b/home/dot_config/mise/oldpowershellmodule.cs
@@ -166,7 +166,7 @@ static void RemoveStaleVersionFolders(string moduleName, IReadOnlyList<Installed
         .Select(location => Path.GetFullPath(location!))
         .Select(Path.GetDirectoryName)
         .Where(root => !string.IsNullOrWhiteSpace(root))
-        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .Distinct(GetPathComparer())
         .ToList();
 
     foreach (var moduleRoot in moduleRoots)
@@ -227,17 +227,19 @@ static async Task<CommandResult> RunPowerShellAsync(string powershell, string sc
     process.StartInfo.UseShellExecute = false;
 
     process.Start();
-    var output = await process.StandardOutput.ReadToEndAsync();
-    var error = await process.StandardError.ReadToEndAsync();
-    await process.WaitForExitAsync();
+    var outputTask = process.StandardOutput.ReadToEndAsync();
+    var errorTask = process.StandardError.ReadToEndAsync();
+    var exitTask = process.WaitForExitAsync();
 
-    return new CommandResult(process.ExitCode, output, error);
+    await Task.WhenAll(outputTask, errorTask, exitTask);
+
+    return new CommandResult(process.ExitCode, await outputTask, await errorTask);
 }
 
 static string? ResolvePowerShellExecutable()
 {
     var candidates = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-        ? ["pwsh.exe", "pwsh", "powershell.exe"]
+        ? ["pwsh.exe", "pwsh"]
         : new[] { "pwsh" };
 
     foreach (var candidate in candidates)
@@ -270,7 +272,19 @@ static bool CanStart(string fileName)
         }
 
         process.WaitForExit(5000);
-        return process.HasExited && process.ExitCode == 0;
+        if (!process.HasExited)
+        {
+            process.Kill(entireProcessTree: true);
+            return false;
+        }
+
+        if (process.ExitCode != 0)
+        {
+            return false;
+        }
+
+        var versionText = process.StandardOutput.ReadToEnd().Trim();
+        return Version.TryParse(versionText, out var version) && version.Major >= 7;
     }
     catch
     {
@@ -288,6 +302,11 @@ static bool IsChildPath(string parentPath, string childPath)
 static string ToPowerShellSingleQuotedString(string value)
 {
     return $"'{value.Replace("'", "''")}'";
+}
+
+static StringComparer GetPathComparer()
+{
+    return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
 }
 
 static bool WildcardMatches(string value, string pattern)

--- a/home/dot_config/mise/oldpowershellmodule.cs
+++ b/home/dot_config/mise/oldpowershellmodule.cs
@@ -1,0 +1,475 @@
+#!/usr/bin/env dotnet
+#:property TargetFramework=net10.0
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+
+var options = CleanupOptions.Parse(args);
+var powershell = ResolvePowerShellExecutable();
+if (powershell is null)
+{
+    Console.Error.WriteLine("PowerShell 7 is required. Install pwsh and run this task again.");
+    return 1;
+}
+
+try
+{
+    var modules = GetInstalledModulesFromModulePaths(options.Patterns);
+    if (modules.Count == 0)
+    {
+        Console.WriteLine("No matching PowerShell modules were found.");
+        return 0;
+    }
+
+    var groups = modules
+        .Where(module => !string.IsNullOrWhiteSpace(module.Name) && !string.IsNullOrWhiteSpace(module.Version))
+        .GroupBy(module => module.Name, StringComparer.OrdinalIgnoreCase)
+        .OrderBy(group => group.Key, StringComparer.OrdinalIgnoreCase);
+
+    foreach (var group in groups)
+    {
+        var orderedModules = group
+            .DistinctBy(module => $"{module.Name}\u001f{module.Version}\u001f{module.InstalledLocation}", StringComparer.OrdinalIgnoreCase)
+            .OrderBy(module => SemanticVersion.Parse(module.Version), SemanticVersion.Comparer)
+            .ToList();
+
+        if (orderedModules.Count <= 1)
+        {
+            Console.WriteLine($"Keep {group.Key}: only one version is installed.");
+            continue;
+        }
+
+        var latest = orderedModules[^1];
+        Console.WriteLine($"Keep {group.Key} {latest.Version}");
+
+        foreach (var module in orderedModules.Take(orderedModules.Count - 1))
+        {
+            await RemoveInstalledModuleAsync(powershell, module, options.DryRun);
+        }
+
+        RemoveStaleVersionFolders(group.Key, orderedModules, options.DryRun);
+    }
+
+    return 0;
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine(ex.Message);
+    return 1;
+}
+
+static List<InstalledModule> GetInstalledModulesFromModulePaths(IReadOnlyList<string> patterns)
+{
+    var modules = new List<InstalledModule>();
+    foreach (var modulePath in GetPowerShellModulePaths())
+    {
+        if (!Directory.Exists(modulePath))
+        {
+            continue;
+        }
+
+        foreach (var moduleDirectory in Directory.EnumerateDirectories(modulePath))
+        {
+            var moduleName = Path.GetFileName(moduleDirectory);
+            if (!patterns.Any(pattern => WildcardMatches(moduleName, pattern)))
+            {
+                continue;
+            }
+
+            foreach (var versionDirectory in Directory.EnumerateDirectories(moduleDirectory))
+            {
+                var version = Path.GetFileName(versionDirectory);
+                if (!SemanticVersion.TryParse(version, out _))
+                {
+                    continue;
+                }
+
+                modules.Add(new InstalledModule(moduleName, version, versionDirectory));
+            }
+        }
+    }
+
+    return modules;
+}
+
+static IReadOnlyList<string> GetPowerShellModulePaths()
+{
+    var paths = new List<string>();
+    var psModulePath = Environment.GetEnvironmentVariable("PSModulePath");
+    if (!string.IsNullOrWhiteSpace(psModulePath))
+    {
+        paths.AddRange(psModulePath.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+    }
+
+    var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+    if (!string.IsNullOrWhiteSpace(home))
+    {
+        paths.Add(Path.Combine(home, ".local", "share", "powershell", "Modules"));
+
+        var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        if (!string.IsNullOrWhiteSpace(documents))
+        {
+            paths.Add(Path.Combine(documents, "PowerShell", "Modules"));
+            paths.Add(Path.Combine(documents, "WindowsPowerShell", "Modules"));
+        }
+    }
+
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    {
+        var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        if (!string.IsNullOrWhiteSpace(programFiles))
+        {
+            paths.Add(Path.Combine(programFiles, "PowerShell", "Modules"));
+            paths.Add(Path.Combine(programFiles, "WindowsPowerShell", "Modules"));
+        }
+    }
+    else
+    {
+        paths.Add("/usr/local/share/powershell/Modules");
+        paths.Add("/opt/microsoft/powershell/7/Modules");
+    }
+
+    return paths
+        .Where(path => !string.IsNullOrWhiteSpace(path))
+        .Select(Path.GetFullPath)
+        .Distinct(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
+        .ToList();
+}
+
+static async Task RemoveInstalledModuleAsync(string powershell, InstalledModule module, bool dryRun)
+{
+    if (dryRun)
+    {
+        Console.WriteLine($"Would uninstall {module.Name} {module.Version}");
+        return;
+    }
+
+    Console.WriteLine($"Uninstall {module.Name} {module.Version}");
+    var script = $$"""
+$ErrorActionPreference = 'Stop'
+Uninstall-Module -Name {{ToPowerShellSingleQuotedString(module.Name)}} -RequiredVersion {{ToPowerShellSingleQuotedString(module.Version)}} -Force
+""";
+
+    var result = await RunPowerShellAsync(powershell, script);
+    if (result.ExitCode != 0)
+    {
+        throw new InvalidOperationException($"Failed to uninstall {module.Name} {module.Version}: {result.Error.Trim()}");
+    }
+}
+
+static void RemoveStaleVersionFolders(string moduleName, IReadOnlyList<InstalledModule> modules, bool dryRun)
+{
+    var moduleRoots = modules
+        .Select(module => module.InstalledLocation)
+        .Where(location => !string.IsNullOrWhiteSpace(location))
+        .Select(location => Path.GetFullPath(location!))
+        .Select(Path.GetDirectoryName)
+        .Where(root => !string.IsNullOrWhiteSpace(root))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToList();
+
+    foreach (var moduleRoot in moduleRoots)
+    {
+        if (!Directory.Exists(moduleRoot))
+        {
+            continue;
+        }
+
+        var moduleDirectory = new DirectoryInfo(moduleRoot);
+        if (!string.Equals(moduleDirectory.Name, moduleName, StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine($"Skip folder cleanup for {moduleRoot}: module root does not match {moduleName}.");
+            continue;
+        }
+
+        var versionFolders = moduleDirectory
+            .EnumerateDirectories()
+            .Where(directory => SemanticVersion.TryParse(directory.Name, out _))
+            .OrderBy(directory => SemanticVersion.Parse(directory.Name), SemanticVersion.Comparer)
+            .ToList();
+
+        if (versionFolders.Count <= 1)
+        {
+            continue;
+        }
+
+        foreach (var folder in versionFolders.Take(versionFolders.Count - 1))
+        {
+            var fullName = Path.GetFullPath(folder.FullName);
+            if (!IsChildPath(moduleDirectory.FullName, fullName))
+            {
+                throw new InvalidOperationException($"Refusing to delete path outside the module root: {fullName}");
+            }
+
+            if (dryRun)
+            {
+                Console.WriteLine($"Would remove folder {fullName}");
+                continue;
+            }
+
+            Console.WriteLine($"Remove folder {fullName}");
+            Directory.Delete(fullName, recursive: true);
+        }
+    }
+}
+
+static async Task<CommandResult> RunPowerShellAsync(string powershell, string script)
+{
+    using var process = new Process();
+    process.StartInfo.FileName = powershell;
+    process.StartInfo.ArgumentList.Add("-NoProfile");
+    process.StartInfo.ArgumentList.Add("-NonInteractive");
+    process.StartInfo.ArgumentList.Add("-Command");
+    process.StartInfo.ArgumentList.Add(script);
+    process.StartInfo.RedirectStandardOutput = true;
+    process.StartInfo.RedirectStandardError = true;
+    process.StartInfo.UseShellExecute = false;
+
+    process.Start();
+    var output = await process.StandardOutput.ReadToEndAsync();
+    var error = await process.StandardError.ReadToEndAsync();
+    await process.WaitForExitAsync();
+
+    return new CommandResult(process.ExitCode, output, error);
+}
+
+static string? ResolvePowerShellExecutable()
+{
+    var candidates = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        ? ["pwsh.exe", "pwsh", "powershell.exe"]
+        : new[] { "pwsh" };
+
+    foreach (var candidate in candidates)
+    {
+        if (CanStart(candidate))
+        {
+            return candidate;
+        }
+    }
+
+    return null;
+}
+
+static bool CanStart(string fileName)
+{
+    try
+    {
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = fileName,
+            ArgumentList = { "-NoProfile", "-NonInteractive", "-Command", "$PSVersionTable.PSVersion.ToString()" },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        });
+
+        if (process is null)
+        {
+            return false;
+        }
+
+        process.WaitForExit(5000);
+        return process.HasExited && process.ExitCode == 0;
+    }
+    catch
+    {
+        return false;
+    }
+}
+
+static bool IsChildPath(string parentPath, string childPath)
+{
+    var parent = Path.GetFullPath(parentPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+    var child = Path.GetFullPath(childPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+    return child.StartsWith(parent, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+}
+
+static string ToPowerShellSingleQuotedString(string value)
+{
+    return $"'{value.Replace("'", "''")}'";
+}
+
+static bool WildcardMatches(string value, string pattern)
+{
+    var regexPattern = "^" + Regex.Escape(pattern).Replace("\\*", ".*").Replace("\\?", ".") + "$";
+    return Regex.IsMatch(value, regexPattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+}
+
+sealed record InstalledModule(string Name, string Version, string? InstalledLocation);
+
+sealed record CommandResult(int ExitCode, string Output, string Error);
+
+sealed record CleanupOptions(IReadOnlyList<string> Patterns, bool DryRun)
+{
+    public static CleanupOptions Parse(string[] args)
+    {
+        var patterns = new List<string> { "Az*", "Microsoft.Entra*", "Microsoft.Graph*" };
+        var dryRun = false;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var arg = args[index];
+            switch (arg)
+            {
+                case "--dry-run":
+                case "--what-if":
+                    dryRun = true;
+                    break;
+                case "--pattern":
+                    if (index + 1 >= args.Length)
+                    {
+                        throw new ArgumentException("--pattern requires a value.");
+                    }
+
+                    patterns.Add(args[++index]);
+                    break;
+                case "--help":
+                case "-h":
+                    Console.WriteLine("Usage: dotnet run --file oldpowershellmodule.cs -- [--dry-run] [--pattern <module-pattern>]");
+                    Environment.Exit(0);
+                    break;
+                default:
+                    throw new ArgumentException($"Unknown argument: {arg}");
+            }
+        }
+
+        return new CleanupOptions(patterns.Distinct(StringComparer.OrdinalIgnoreCase).ToList(), dryRun);
+    }
+}
+
+sealed class SemanticVersion
+{
+    private static readonly Regex VersionRegex = new(
+        @"^(?<version>\d+(?:\.\d+){0,3})(?:-(?<prerelease>[0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$",
+        RegexOptions.Compiled);
+
+    public static readonly IComparer<SemanticVersion> Comparer = new SemanticVersionComparer();
+
+    private SemanticVersion(string original, IReadOnlyList<int> parts, IReadOnlyList<string> prerelease)
+    {
+        Original = original;
+        Parts = parts;
+        Prerelease = prerelease;
+    }
+
+    public string Original { get; }
+
+    public IReadOnlyList<int> Parts { get; }
+
+    public IReadOnlyList<string> Prerelease { get; }
+
+    public static SemanticVersion Parse(string value)
+    {
+        if (TryParse(value, out var version))
+        {
+            return version;
+        }
+
+        return new SemanticVersion(value, [0], [value]);
+    }
+
+    public static bool TryParse(string value, out SemanticVersion version)
+    {
+        var match = VersionRegex.Match(value);
+        if (!match.Success)
+        {
+            version = null!;
+            return false;
+        }
+
+        var parts = match.Groups["version"].Value
+            .Split('.', StringSplitOptions.RemoveEmptyEntries)
+            .Select(int.Parse)
+            .ToList();
+
+        var prerelease = match.Groups["prerelease"].Success
+            ? match.Groups["prerelease"].Value.Split('.', StringSplitOptions.RemoveEmptyEntries).ToList()
+            : [];
+
+        version = new SemanticVersion(value, parts, prerelease);
+        return true;
+    }
+
+    private sealed class SemanticVersionComparer : IComparer<SemanticVersion>
+    {
+        public int Compare(SemanticVersion? x, SemanticVersion? y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            if (x is null)
+            {
+                return -1;
+            }
+
+            if (y is null)
+            {
+                return 1;
+            }
+
+            var maxPartCount = Math.Max(x.Parts.Count, y.Parts.Count);
+            for (var index = 0; index < maxPartCount; index++)
+            {
+                var left = index < x.Parts.Count ? x.Parts[index] : 0;
+                var right = index < y.Parts.Count ? y.Parts[index] : 0;
+                var result = left.CompareTo(right);
+                if (result != 0)
+                {
+                    return result;
+                }
+            }
+
+            if (x.Prerelease.Count == 0 && y.Prerelease.Count == 0)
+            {
+                return 0;
+            }
+
+            if (x.Prerelease.Count == 0)
+            {
+                return 1;
+            }
+
+            if (y.Prerelease.Count == 0)
+            {
+                return -1;
+            }
+
+            var maxPrereleaseCount = Math.Max(x.Prerelease.Count, y.Prerelease.Count);
+            for (var index = 0; index < maxPrereleaseCount; index++)
+            {
+                if (index >= x.Prerelease.Count)
+                {
+                    return -1;
+                }
+
+                if (index >= y.Prerelease.Count)
+                {
+                    return 1;
+                }
+
+                var left = x.Prerelease[index];
+                var right = y.Prerelease[index];
+                var leftIsNumber = int.TryParse(left, out var leftNumber);
+                var rightIsNumber = int.TryParse(right, out var rightNumber);
+
+                var result = (leftIsNumber, rightIsNumber) switch
+                {
+                    (true, true) => leftNumber.CompareTo(rightNumber),
+                    (true, false) => -1,
+                    (false, true) => 1,
+                    _ => string.CompareOrdinal(left, right)
+                };
+
+                if (result != 0)
+                {
+                    return result;
+                }
+            }
+
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add mise tasks to preview and remove older `Az*`, `Microsoft.Entra*`, and `Microsoft.Graph*` PowerShell module versions
- Add a C# file-based cleanup app that detects installed module versions, keeps the newest version, and removes stale folders safely
- Document usage for macOS and Windows in English and Japanese
- Update the mise template to use .NET 10 and fix the `UV_PYTHON` template reference

## Testing
- Not run (not requested)